### PR TITLE
Get code generation and most API tests working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/main/resources/vertx_python/*/
 src/test/resources/testmodel_python/*.py
 src/test/resources/testmodel_python/
 src/test/resources/acme_python/
+target

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,4 @@
 .DS_Store
 .*.swp
 *.bak
-src/main/resources/vertx_python/*.py
-src/main/resources/vertx_python/*/
-src/test/resources/testmodel_python/*.py
-src/test/resources/testmodel_python/
-src/test/resources/acme_python/
 target

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 .DS_Store
 .*.swp
 *.bak
+src/main/resources/vertx_python/*.py
+src/main/resources/vertx_python/*/
+src/test/resources/testmodel_python/*.py
+src/test/resources/testmodel_python/
+src/test/resources/acme_python/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 *.pyc
 .DS_Store
+.*.swp
+*.bak

--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
       <classifier>sources</classifier>
       <scope>provided</scope>
     </dependency>
@@ -167,6 +163,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>vertx-lang-python</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
 
   <properties>
-    <stack.version>3.1.0-SNAPSHOT</stack.version>
+    <stack.version>3.3.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-parent</artifactId>
-    <version>5</version>
+    <version>9</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -18,6 +18,13 @@
     <stack.version>3.3.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
+
+   <netty.version>4.1.0.CR7</netty.version>
+   <log4j.version>1.2.17</log4j.version>
+   <slf4j.version>1.7.21</slf4j.version>
+   <log4j2.version>2.5</log4j2.version>
+   <junit.version>4.12</junit.version>
+
   </properties>
 
   <dependencyManagement>
@@ -38,6 +45,12 @@
       <groupId>net.sf.py4j</groupId>
       <artifactId>py4j</artifactId>
       <version>0.8.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+      <version>${netty.version}</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -74,6 +87,18 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.6.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>vertx-lang-python</artifactId>
-  <version>3.0.0</version>
+  <version>3.1.0-SNAPSHOT</version>
 
   <properties>
-    <stack.version>3.0.0</stack.version>
+    <stack.version>3.1.0-SNAPSHOT</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -178,103 +178,105 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.bsc.maven</groupId>
-        <artifactId>maven-processor-plugin</artifactId>
-        <version>2.2.4</version>
-        <executions>
-          <!-- Run the annotation processor on vertx-core and generate the python API -->
-          <execution>
-            <id>generate-vertx-core</id>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <systemProperties>
-                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
-              </systemProperties>
-              <processors>
-                <processor>io.vertx.codegen.CodeGenProcessor</processor>
-              </processors>
-              <optionMap>
-                <outputDirectory>${project.basedir}/src/main</outputDirectory>
-              </optionMap>
-              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
-            </configuration>
-          </execution>
-
-          <!-- We have to run the annotation processor again to process doc overrides -->
-          <execution>
-            <id>docgen-docs</id>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <phase>prepare-package</phase>
-            <configuration>
-              <systemProperties>
-                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
-              </systemProperties>
-              <processors>
-                <processor>io.vertx.docgen.DocGenProcessor</processor>
-              </processors>
-              <optionMap>
-                <docgen.output>${asciidoc.dir}/python</docgen.output>
-              </optionMap>
-              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
-            </configuration>
-          </execution>
-
-          <!-- We have to run the annotation processor again to process doc overrides -->
-          <execution>
-            <id>docgen-docoverrides</id>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <phase>prepare-package</phase>
-            <configuration>
-              <systemProperties>
-                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
-              </systemProperties>
-              <processors>
-                <processor>io.vertx.docgen.DocGenProcessor</processor>
-              </processors>
-              <optionMap>
-                <docgen.output>${asciidoc.dir}/python</docgen.output>
-              </optionMap>
-              <sourceDirectory>src/main/docoverride</sourceDirectory>
-            </configuration>
-          </execution>
-
-          <!-- Run the annotation processor on codegen and generate the python codegen -->
-          <execution>
-            <id>generate-codegen</id>
-            <goals>
-              <goal>process</goal>
-            </goals>
-            <phase>generate-test-sources</phase>
-            <configuration>
-              <systemProperties>
-                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
-              </systemProperties>
-              <processors>
-                <processor>io.vertx.codegen.CodeGenProcessor</processor>
-              </processors>
-              <optionMap>
-                <outputDirectory>${project.basedir}/src/test</outputDirectory>
-              </optionMap>
-              <sourceDirectory>${project.build.directory}/sources/codegen</sourceDirectory>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-          </dependency>
-        </dependencies>
-      </plugin>
+<!--
+   -      <plugin>
+   -        <groupId>org.bsc.maven</groupId>
+   -        <artifactId>maven-processor-plugin</artifactId>
+   -        <version>2.2.4</version>
+   -        <executions>
+   -          [> Run the annotation processor on vertx-core and generate the python API <]
+   -          <execution>
+   -            <id>generate-vertx-core</id>
+   -            <goals>
+   -              <goal>process</goal>
+   -            </goals>
+   -            <phase>generate-sources</phase>
+   -            <configuration>
+   -              <systemProperties>
+   -                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+   -              </systemProperties>
+   -              <processors>
+   -                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+   -              </processors>
+   -              <optionMap>
+   -                <outputDirectory>${project.basedir}/src/main</outputDirectory>
+   -              </optionMap>
+   -              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
+   -            </configuration>
+   -          </execution>
+   -
+   -          [> We have to run the annotation processor again to process doc overrides <]
+   -          <execution>
+   -            <id>docgen-docs</id>
+   -            <goals>
+   -              <goal>process</goal>
+   -            </goals>
+   -            <phase>prepare-package</phase>
+   -            <configuration>
+   -              <systemProperties>
+   -                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+   -              </systemProperties>
+   -              <processors>
+   -                <processor>io.vertx.docgen.DocGenProcessor</processor>
+   -              </processors>
+   -              <optionMap>
+   -                <docgen.output>${asciidoc.dir}/python</docgen.output>
+   -              </optionMap>
+   -              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
+   -            </configuration>
+   -          </execution>
+   -
+   -          [> We have to run the annotation processor again to process doc overrides <]
+   -          <execution>
+   -            <id>docgen-docoverrides</id>
+   -            <goals>
+   -              <goal>process</goal>
+   -            </goals>
+   -            <phase>prepare-package</phase>
+   -            <configuration>
+   -              <systemProperties>
+   -                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+   -              </systemProperties>
+   -              <processors>
+   -                <processor>io.vertx.docgen.DocGenProcessor</processor>
+   -              </processors>
+   -              <optionMap>
+   -                <docgen.output>${asciidoc.dir}/python</docgen.output>
+   -              </optionMap>
+   -              <sourceDirectory>src/main/docoverride</sourceDirectory>
+   -            </configuration>
+   -          </execution>
+   -
+   -          [> Run the annotation processor on codegen and generate the python codegen <]
+   -          <execution>
+   -            <id>generate-codegen</id>
+   -            <goals>
+   -              <goal>process</goal>
+   -            </goals>
+   -            <phase>generate-test-sources</phase>
+   -            <configuration>
+   -              <systemProperties>
+   -                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+   -              </systemProperties>
+   -              <processors>
+   -                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+   -              </processors>
+   -              <optionMap>
+   -                <outputDirectory>${project.basedir}/src/test</outputDirectory>
+   -              </optionMap>
+   -              <sourceDirectory>${project.build.directory}/sources/codegen</sourceDirectory>
+   -            </configuration>
+   -          </execution>
+   -        </executions>
+   -        <dependencies>
+   -          <dependency>
+   -            <groupId>junit</groupId>
+   -            <artifactId>junit</artifactId>
+   -            <version>4.11</version>
+   -          </dependency>
+   -        </dependencies>
+   -      </plugin>
+   -->
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>vertx-lang-python</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.0.0</version>
 
   <properties>
-    <stack.version>3.0.0-SNAPSHOT</stack.version>
+    <stack.version>3.0.0</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
     <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,32 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <systemPropertyVariables>
+              <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+            </systemPropertyVariables>
+            <additionalClasspathElements>
+              <additionalClasspathElement>${project.build.testSourceDirectory}</additionalClasspathElement>
+              <additionalClasspathElement>${project.basedir}/src/main/resources</additionalClasspathElement>
+            </additionalClasspathElements>
           </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-clean</id>
+              <configuration>
+                <filesets>
+                  <fileset>
+                    <directory>${asciidoc.dir}</directory>
+                  </fileset>
+                </filesets>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -138,6 +159,21 @@
               <includeTypes>jar</includeTypes>
               <includeClassifiers>sources</includeClassifiers>
               <outputDirectory>${project.build.directory}/sources/vertx-core</outputDirectory>
+            </configuration>
+          </execution>
+          <!-- Unpack codegen source code to target/sources/codegen -->
+          <execution>
+            <id>unpack-codegen</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeGroupIds>io.vertx</includeGroupIds>
+              <includeArtifactIds>vertx-codegen</includeArtifactIds>
+              <includeTypes>jar</includeTypes>
+              <includeClassifiers>tck-sources</includeClassifiers>
+              <outputDirectory>${project.build.directory}/sources/codegen</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -231,28 +267,34 @@
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
-        <artifactId>maven-source-plugin</artifactId>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>asciidoctor-maven-plugin</artifactId>
+        <version>1.5.2</version>
         <executions>
           <execution>
-            <phase>package</phase>
             <goals>
-              <goal>jar-no-fork</goal>
+              <goal>process-asciidoc</goal>
             </goals>
+            <phase>package</phase>
+            <configuration>
+              <sourceDirectory>${asciidoc.dir}</sourceDirectory>
+              <outputDirectory>${project.build.directory}/docs/vertx-core</outputDirectory>
+              <backend>html</backend>
+              <doctype>book</doctype>
+              <preserveDirectories>true</preserveDirectories>
+              <relativeBaseDir>true</relativeBaseDir>
+            </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
-        <configuration>
-          <additionalClasspathElements>
-            <additionalClasspathElement>${project.build.testSourceDirectory}</additionalClasspathElement>
-            <additionalClasspathElement>${project.basedir}/src/main/resources</additionalClasspathElement>
-          </additionalClasspathElements>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -178,105 +178,103 @@
           </execution>
         </executions>
       </plugin>
-<!--
-   -      <plugin>
-   -        <groupId>org.bsc.maven</groupId>
-   -        <artifactId>maven-processor-plugin</artifactId>
-   -        <version>2.2.4</version>
-   -        <executions>
-   -          [> Run the annotation processor on vertx-core and generate the python API <]
-   -          <execution>
-   -            <id>generate-vertx-core</id>
-   -            <goals>
-   -              <goal>process</goal>
-   -            </goals>
-   -            <phase>generate-sources</phase>
-   -            <configuration>
-   -              <systemProperties>
-   -                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
-   -              </systemProperties>
-   -              <processors>
-   -                <processor>io.vertx.codegen.CodeGenProcessor</processor>
-   -              </processors>
-   -              <optionMap>
-   -                <outputDirectory>${project.basedir}/src/main</outputDirectory>
-   -              </optionMap>
-   -              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
-   -            </configuration>
-   -          </execution>
-   -
-   -          [> We have to run the annotation processor again to process doc overrides <]
-   -          <execution>
-   -            <id>docgen-docs</id>
-   -            <goals>
-   -              <goal>process</goal>
-   -            </goals>
-   -            <phase>prepare-package</phase>
-   -            <configuration>
-   -              <systemProperties>
-   -                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
-   -              </systemProperties>
-   -              <processors>
-   -                <processor>io.vertx.docgen.DocGenProcessor</processor>
-   -              </processors>
-   -              <optionMap>
-   -                <docgen.output>${asciidoc.dir}/python</docgen.output>
-   -              </optionMap>
-   -              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
-   -            </configuration>
-   -          </execution>
-   -
-   -          [> We have to run the annotation processor again to process doc overrides <]
-   -          <execution>
-   -            <id>docgen-docoverrides</id>
-   -            <goals>
-   -              <goal>process</goal>
-   -            </goals>
-   -            <phase>prepare-package</phase>
-   -            <configuration>
-   -              <systemProperties>
-   -                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
-   -              </systemProperties>
-   -              <processors>
-   -                <processor>io.vertx.docgen.DocGenProcessor</processor>
-   -              </processors>
-   -              <optionMap>
-   -                <docgen.output>${asciidoc.dir}/python</docgen.output>
-   -              </optionMap>
-   -              <sourceDirectory>src/main/docoverride</sourceDirectory>
-   -            </configuration>
-   -          </execution>
-   -
-   -          [> Run the annotation processor on codegen and generate the python codegen <]
-   -          <execution>
-   -            <id>generate-codegen</id>
-   -            <goals>
-   -              <goal>process</goal>
-   -            </goals>
-   -            <phase>generate-test-sources</phase>
-   -            <configuration>
-   -              <systemProperties>
-   -                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
-   -              </systemProperties>
-   -              <processors>
-   -                <processor>io.vertx.codegen.CodeGenProcessor</processor>
-   -              </processors>
-   -              <optionMap>
-   -                <outputDirectory>${project.basedir}/src/test</outputDirectory>
-   -              </optionMap>
-   -              <sourceDirectory>${project.build.directory}/sources/codegen</sourceDirectory>
-   -            </configuration>
-   -          </execution>
-   -        </executions>
-   -        <dependencies>
-   -          <dependency>
-   -            <groupId>junit</groupId>
-   -            <artifactId>junit</artifactId>
-   -            <version>4.11</version>
-   -          </dependency>
-   -        </dependencies>
-   -      </plugin>
-   -->
+      <plugin>
+        <groupId>org.bsc.maven</groupId>
+        <artifactId>maven-processor-plugin</artifactId>
+        <version>2.2.4</version>
+        <executions>
+          <!-- Run the annotation processor on vertx-core and generate the python API -->
+          <execution>
+            <id>generate-vertx-core</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <systemProperties>
+                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              </systemProperties>
+              <processors>
+                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <outputDirectory>${project.basedir}/src/main</outputDirectory>
+              </optionMap>
+              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
+            </configuration>
+          </execution>
+
+          <!-- We have to run the annotation processor again to process doc overrides -->
+          <execution>
+            <id>docgen-docs</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>prepare-package</phase>
+            <configuration>
+              <systemProperties>
+                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              </systemProperties>
+              <processors>
+                <processor>io.vertx.docgen.DocGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <docgen.output>${asciidoc.dir}/python</docgen.output>
+              </optionMap>
+              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
+            </configuration>
+          </execution>
+
+          <!-- We have to run the annotation processor again to process doc overrides -->
+          <execution>
+            <id>docgen-docoverrides</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>prepare-package</phase>
+            <configuration>
+              <systemProperties>
+                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              </systemProperties>
+              <processors>
+                <processor>io.vertx.docgen.DocGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <docgen.output>${asciidoc.dir}/python</docgen.output>
+              </optionMap>
+              <sourceDirectory>src/main/docoverride</sourceDirectory>
+            </configuration>
+          </execution>
+
+          <!-- Run the annotation processor on codegen and generate the python codegen -->
+          <execution>
+            <id>generate-codegen</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <systemProperties>
+                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              </systemProperties>
+              <processors>
+                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <outputDirectory>${project.basedir}/src/test</outputDirectory>
+              </optionMap>
+              <sourceDirectory>${project.build.directory}/sources/codegen</sourceDirectory>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+          </dependency>
+        </dependencies>
+      </plugin>
       <plugin>
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,11 @@
   <dependencies>
 
     <dependency>
+      <groupId>net.sf.py4j</groupId>
+      <artifactId>py4j</artifactId>
+      <version>0.8.2.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <artifactId>maven-processor-plugin</artifactId>
         <version>2.2.4</version>
         <executions>
-          <!-- Run the annotation processor on vertx-core and generate the js API -->
+          <!-- Run the annotation processor on vertx-core and generate the python API -->
           <execution>
             <id>generate-vertx-core</id>
             <goals>
@@ -178,7 +178,7 @@
                 <processor>io.vertx.docgen.DocGenProcessor</processor>
               </processors>
               <optionMap>
-                <docgen.output>${asciidoc.dir}/js</docgen.output>
+                <docgen.output>${asciidoc.dir}/python</docgen.output>
               </optionMap>
               <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
             </configuration>
@@ -199,13 +199,13 @@
                 <processor>io.vertx.docgen.DocGenProcessor</processor>
               </processors>
               <optionMap>
-                <docgen.output>${asciidoc.dir}/js</docgen.output>
+                <docgen.output>${asciidoc.dir}/python</docgen.output>
               </optionMap>
               <sourceDirectory>src/main/docoverride</sourceDirectory>
             </configuration>
           </execution>
 
-          <!-- Run the annotation processor on codegen and generate the js codegen -->
+          <!-- Run the annotation processor on codegen and generate the python codegen -->
           <execution>
             <id>generate-codegen</id>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -4,59 +4,78 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <groupId>io.vertx</groupId>
+    <artifactId>vertx-parent</artifactId>
+    <version>5</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.vertx</groupId>
-  <artifactId>vertx-python</artifactId>
+  <artifactId>vertx-lang-python</artifactId>
   <version>3.0.0-SNAPSHOT</version>
 
+  <properties>
+    <stack.version>3.0.0-SNAPSHOT</stack.version>
+    <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
+    <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-dependencies</artifactId>
+        <version>${stack.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>codegen</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <artifactId>vertx-codegen</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>codegen</artifactId>
-      <version>1.0-SNAPSHOT</version>
-      <classifier>sources</classifier>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <artifactId>vertx-docgen</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
-      <classifier>sources</classifier>
     </dependency>
     <dependency>
-      <groupId>net.sf.py4j</groupId>
-      <artifactId>py4j</artifactId>
-      <version>0.8.2.1</version>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <classifier>sources</classifier>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codetrans</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.16</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.6.2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.mvel</groupId>
       <artifactId>mvel2</artifactId>
       <version>2.2.0.Final</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -64,9 +83,28 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <classifier>tck</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <classifier>tck-sources</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
+      <classifier>sources</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
+
     <pluginManagement>
       <plugins>
         <plugin>
@@ -81,25 +119,20 @@
     <plugins>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
         <executions>
           <!-- Unpack vertx-core source code to target/vertx-core -->
           <execution>
-            <id>unpack</id>
+            <id>unpack-vertx-core</id>
             <phase>generate-sources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>io.vertx</groupId>
-                  <artifactId>vertx-core</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
-                  <classifier>sources</classifier>
-                </artifactItem>
-              </artifactItems>
-              <outputDirectory>${project.build.directory}/vertx-core</outputDirectory>
+              <includeGroupIds>io.vertx</includeGroupIds>
+              <includeArtifactIds>vertx-core</includeArtifactIds>
+              <includeTypes>jar</includeTypes>
+              <includeClassifiers>sources</includeClassifiers>
+              <outputDirectory>${project.build.directory}/sources/vertx-core</outputDirectory>
             </configuration>
           </execution>
         </executions>
@@ -109,21 +142,87 @@
         <artifactId>maven-processor-plugin</artifactId>
         <version>2.2.4</version>
         <executions>
-          <!-- Run the annotation processor on vertx-core and generate the Python API -->
+          <!-- Run the annotation processor on vertx-core and generate the js API -->
           <execution>
-            <id>codegen</id>
+            <id>generate-vertx-core</id>
             <goals>
               <goal>process</goal>
             </goals>
             <phase>generate-sources</phase>
             <configuration>
+              <systemProperties>
+                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              </systemProperties>
               <processors>
                 <processor>io.vertx.codegen.CodeGenProcessor</processor>
               </processors>
               <optionMap>
                 <outputDirectory>${project.basedir}/src/main</outputDirectory>
               </optionMap>
-              <sourceDirectory>${project.build.directory}/vertx-core</sourceDirectory>
+              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
+            </configuration>
+          </execution>
+
+          <!-- We have to run the annotation processor again to process doc overrides -->
+          <execution>
+            <id>docgen-docs</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>prepare-package</phase>
+            <configuration>
+              <systemProperties>
+                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              </systemProperties>
+              <processors>
+                <processor>io.vertx.docgen.DocGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <docgen.output>${asciidoc.dir}/js</docgen.output>
+              </optionMap>
+              <sourceDirectory>${project.build.directory}/sources/vertx-core</sourceDirectory>
+            </configuration>
+          </execution>
+
+          <!-- We have to run the annotation processor again to process doc overrides -->
+          <execution>
+            <id>docgen-docoverrides</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>prepare-package</phase>
+            <configuration>
+              <systemProperties>
+                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              </systemProperties>
+              <processors>
+                <processor>io.vertx.docgen.DocGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <docgen.output>${asciidoc.dir}/js</docgen.output>
+              </optionMap>
+              <sourceDirectory>src/main/docoverride</sourceDirectory>
+            </configuration>
+          </execution>
+
+          <!-- Run the annotation processor on codegen and generate the js codegen -->
+          <execution>
+            <id>generate-codegen</id>
+            <goals>
+              <goal>process</goal>
+            </goals>
+            <phase>generate-test-sources</phase>
+            <configuration>
+              <systemProperties>
+                <java.util.logging.SimpleFormatter.format>%4$s: %3$s - %5$s %6$s%n</java.util.logging.SimpleFormatter.format>
+              </systemProperties>
+              <processors>
+                <processor>io.vertx.codegen.CodeGenProcessor</processor>
+              </processors>
+              <optionMap>
+                <outputDirectory>${project.basedir}/src/test</outputDirectory>
+              </optionMap>
+              <sourceDirectory>${project.build.directory}/sources/codegen</sourceDirectory>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
+++ b/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
@@ -118,6 +118,9 @@ public class PythonVerticleFactory implements VerticleFactory {
           gateway.start();
           connected = true;
         } catch (Exception e) {
+          // If port seemed to be taken, increment port/client_port together.
+          // This is kind of hacky, since we really have no confirmation that
+          // client_port is unused, even if port works.
           port++;
           client_port++;
         }

--- a/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
+++ b/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
@@ -1,7 +1,6 @@
 package io.vertx.lang.python;
 
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;

--- a/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
+++ b/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
@@ -58,7 +58,7 @@ public class PythonVerticleFactory implements VerticleFactory {
 
     @Override
     public void start(Future<Void> startFuture) throws Exception {
-      ProcessBuilder pb = new ProcessBuilder("python", verticleName, String.valueOf(port), String.valueOf(client_port));
+      ProcessBuilder pb = new ProcessBuilder("python", "-u", verticleName, String.valueOf(port), String.valueOf(client_port));
       pb.redirectOutput(Redirect.INHERIT);
       pb.redirectError(Redirect.INHERIT);
       process = pb.start();

--- a/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
+++ b/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
@@ -33,7 +33,7 @@ public class PythonVerticleFactory implements VerticleFactory {
 
   @Override
   public String prefix() {
-    return "python";
+    return "py";
   }
 
   @Override

--- a/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
+++ b/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
@@ -39,6 +39,7 @@ public class PythonVerticleFactory implements VerticleFactory {
   @Override
   public Verticle createVerticle(String verticleName, ClassLoader classLoader) throws Exception {
     init();
+    verticleName = VerticleFactory.removePrefix(verticleName);
     return new PythonVerticle(verticleName);
   }
 

--- a/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
+++ b/src/main/java/io/vertx/lang/python/PythonVerticleFactory.java
@@ -1,6 +1,7 @@
 package io.vertx.lang.python;
 
 import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
@@ -37,6 +38,7 @@ public class PythonVerticleFactory implements VerticleFactory {
 
   @Override
   public Verticle createVerticle(String verticleName, ClassLoader classLoader) throws Exception {
+    init();
     return new PythonVerticle(verticleName);
   }
 
@@ -55,7 +57,6 @@ public class PythonVerticleFactory implements VerticleFactory {
 
     @Override
     public void start(Future<Void> startFuture) throws Exception {
-      init();
       ProcessBuilder pb = new ProcessBuilder("python", verticleName, String.valueOf(port), String.valueOf(client));
       pb.redirectOutput(Redirect.INHERIT);
       pb.redirectError(Redirect.INHERIT);

--- a/src/main/java/io/vertx/lang/python/TypeHelper.java
+++ b/src/main/java/io/vertx/lang/python/TypeHelper.java
@@ -1,0 +1,54 @@
+package io.vertx.lang.python;
+
+import java.util.List;
+import java.util.Set;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.function.Function;
+import java.lang.Number;
+
+public class TypeHelper {
+
+  public static <T> List<T> listToT(List<Number> listT, Function<? super Number, T> func) {
+    List<T> ret = listT.stream()
+                     .map(func)
+                     .collect(Collectors.toList());
+    return ret;
+  }
+
+  public static <T> Set<T> setToT(Set<Number> setT, Function<? super Number, T> func) {
+    Set<T> ret = setT.stream()
+                     .map(func)
+                     .collect(Collectors.toSet());
+    return ret;
+  }
+
+  public static <S, T> Map<S, T> mapToT(Map<S, Number> mapT, Function<? super Number, T> func) {
+    Map<S, T> ret = mapT.entrySet()
+                     .stream()
+                     .collect(Collectors.toMap(Map.Entry::getKey,
+                                               e-> func.apply(e.getValue())));
+    return ret;
+  }
+
+  public static List<Byte> toByteList(List<Number> listByte) {
+    return listToT(listByte, Number::byteValue);
+  }
+  public static List<Short> toShortList(List<Number> listShort) {
+    return listToT(listShort, Number::shortValue);
+  }
+
+  public static Set<Byte> toByteSet(Set<Number> setByte) {
+    return setToT(setByte, Number::byteValue);
+  }
+  public static Set<Short> toShortSet(Set<Number> setShort) {
+    return setToT(setShort, Number::shortValue);
+  }
+
+  public static <T> Map<T, Byte> toByteMap(Map<T, Number> mapByte) {
+    return mapToT(mapByte, Number::byteValue);
+  }
+  public static <T> Map<T, Short> toShortMap(Map<T, Number> mapShort) {
+    return mapToT(mapShort, Number::shortValue);
+  }
+}

--- a/src/main/resources/codegen.json
+++ b/src/main/resources/codegen.json
@@ -8,11 +8,6 @@
     },
     {
       "kind": "class",
-      "fileName": "'resources/' + type.raw.moduleName + '_python/__init__.py'",
-      "templateFileName": "vertx_python/template/init.templ"
-    },
-    {
-      "kind": "class",
       "fileName": "'resources/' + type.raw.moduleName + '_python/' + fqn.substring(fqn.lastIndexOf('.', fqn.lastIndexOf('.') - 1) + 1, fqn.lastIndexOf('.')) + '/__init__.py'",
       "templateFileName": "vertx_python/template/init.templ"
     }

--- a/src/main/resources/codegen.json
+++ b/src/main/resources/codegen.json
@@ -7,9 +7,14 @@
       "templateFileName": "vertx_python/template/python.templ"
     },
     {
-      "kind": "class",
-      "fileName": "'resources/' + type.raw.moduleName + '_python/' + fqn.substring(fqn.lastIndexOf('.', fqn.lastIndexOf('.') - 1) + 1, fqn.lastIndexOf('.')) + '/__init__.py'",
+      "kind": "module",
+      "fileName": "'resources/' + name + '_python/__init__.py'",
       "templateFileName": "vertx_python/template/init.templ"
+    },
+    {
+      "kind" : "package",
+      "fileName" : "'resources/' +  module.name + '_python/' + fqn.substring(fqn.lastIndexOf('.') + 1, fqn.length()) + '/__init__.py'",
+      "templateFileName": "vertx_python/template/init2.templ"
     }
   ]
 }

--- a/src/main/resources/vertx_python/compat.py
+++ b/src/main/resources/vertx_python/compat.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals, absolute_import
+from __future__ import unicode_literals, print_function, absolute_import
 
 import sys
 
@@ -8,3 +8,4 @@ if sys.version_info[0] < 3:
 else:
     long = int
     basestring = str
+    unicode = str

--- a/src/main/resources/vertx_python/compat.py
+++ b/src/main/resources/vertx_python/compat.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals, absolute_import
+
+import sys
+
+if sys.version_info[0] < 3:
+    long = long
+    basestring = basestring
+else:
+    long = int
+    basestring = str

--- a/src/main/resources/vertx_python/compat.py
+++ b/src/main/resources/vertx_python/compat.py
@@ -5,6 +5,7 @@ import sys
 if sys.version_info[0] < 3:
     long = long
     basestring = basestring
+    unicode = unicode
 else:
     long = int
     basestring = str

--- a/src/main/resources/vertx_python/compat.py
+++ b/src/main/resources/vertx_python/compat.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, print_function, absolute_import
 
 import sys
+from py4j.compat import iteritems
 
 if sys.version_info[0] < 3:
     long = long

--- a/src/main/resources/vertx_python/compat.py
+++ b/src/main/resources/vertx_python/compat.py
@@ -7,7 +7,9 @@ if sys.version_info[0] < 3:
     long = long
     basestring = basestring
     unicode = unicode
+    reduce = reduce
 else:
     long = int
     basestring = str
     unicode = str
+    from functools import reduce

--- a/src/main/resources/vertx_python/template/init2.templ
+++ b/src/main/resources/vertx_python/template/init2.templ
@@ -1,0 +1,2 @@
+@comment{"Generate an init.py file"}
+@comment{"========================"}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -65,8 +65,6 @@
 			@else{}
 				Async@{param.type.args[0].args[0].name}Handler(@{convertName(paramName)})
 			@end{}
-		@else{param.type.args[0].name.equals("java.lang.Void")}
-			@{convertName(paramName)}
 		@else{}
 			@if{param.type.args[0].raw != null}
 				@{param.type.args[0].raw.simpleName}Handler(@{convertName(paramName)})
@@ -397,7 +395,7 @@ result.result()
 
 from __future__ import unicode_literals, print_function, absolute_import\n
 from vertx_python import util\n
-from vertx_python.compat import *\n
+from vertx_python.compat import long, basestring\n
 \n
 
 @comment{"Initalize the Vert.x client if necessary"}
@@ -405,20 +403,26 @@ from vertx_python.compat import *\n
 util.vertx_init()\n
 \n
 
-@comment{"Generate the imports"}
 
 @code{imported = []}
 @foreach{importedType : importedTypes}
 	@code{impType = importedType.raw.name}
-	@if{impType.contains("vertx")}
+	@code{impPackage = impType.substring(impType.lastIndexOf('.', impType.lastIndexOf('.') - 1) + 1, impType.lastIndexOf('.'))}
+	@if{impType.substring(0, impType.lastIndexOf('.')).equals(ifacePackageName)}
+		@if{!referencedDataObjectTypes.contains(importedType) && !importedType.raw.simpleName.equals(ifaceSimpleName)}
+			@comment{"from @{importedType.moduleName}_python.@{impPackage}.@{convertName(importedType.simpleName)} import @{importedType.simpleName}\n"}
+			@comment{"@code{imported.add(importedType.simpleName)}"}
+		@end{}
 	@end{}
 @end{}
 
 @foreach{referencedType : referencedTypes}
-	@code{refedType = referencedType.raw.name}
-	@code{refedPackage = refedType.substring(refedType.lastIndexOf('.', refedType.lastIndexOf('.') - 1) + 1, refedType.lastIndexOf('.'))}
-	from @{referencedType.moduleName}_python.@{refedPackage}.@{convertName(referencedType.simpleName)} import @{referencedType.simpleName}\n
-	@code{imported.add(referencedType.simpleName)}
+	@if{!imported.contains(referencedType.simpleName)}
+		@code{refedType = referencedType.raw.name}
+		@code{refedPackage = refedType.substring(refedType.lastIndexOf('.', refedType.lastIndexOf('.') - 1) + 1, refedType.lastIndexOf('.'))}
+		from @{referencedType.moduleName}_python.@{refedPackage}.@{convertName(referencedType.simpleName)} import @{referencedType.simpleName}\n
+		@code{imported.add(referencedType.simpleName)}
+	@end{}
 @end{}
 \n
 

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -51,7 +51,7 @@
 				out += ", ";
 			}
 			argName = convertName(param.name);
-			out += convParam(overloaded, argName, param.type);
+			out += convParam(argName, param.type);
 		}
 		out += ")";
 		return out;	
@@ -90,13 +90,9 @@
 		} else if (kind == CLASS_DATA_OBJECT) {
 			return "util.data_object_to_json(" + expr + ", hashable=" + boolToStr(hashable) + ")";
 		} else if (kind == CLASS_MAP) {
-			/*
-			*var keyType = type.args[0];
-			*var valueType = type.args[1];
-			*return "{" + convReturn(keyType, "k", hashable) + " : " + 
-            *       convReturn(valueType, "v", hashable) + " for k,v in " + expr + ".items()}";
-			*/
-			return expr;
+			var valueType = type.args[1];
+			return "util.java_map_to_python(" + expr + ", lambda x:" + 
+                    convReturn(valueType, "x", hashable) + ", lambda y:" + convParam("y", valueType) + ")";
 		} else if (kind == CLASS_API) {
 			if (type.raw != null) {
 				if (type.raw.simpleName.equals("Throwable")) {
@@ -146,7 +142,7 @@
 		}
 	}
 
-	def convParam(overloaded, argName, type) {
+	def convParam(argName, type) {
 		var paramName = argName;
 		var kind = type.kind;
 		var typeName = type.name;
@@ -179,17 +175,24 @@
 				return "util.convert_float_to_java(" + convertName(paramName) + ")";
 			} else if (typeName == 'double' || typeName == 'java.lang.Double') {
 				return "util.convert_double_to_java(" + convertName(paramName) + ")";
+			} else if (typeName == 'boolean' || typeName == 'java.lang.Boolean') {
+				return "util.convert_boolean_to_java(" + convertName(paramName) + ")";
 			} else {
 				return convertName(paramName);
 			}
         } else if (kind == CLASS_LIST) {
 			var element = type.args[0];
-			return "[" + convParam(overloaded, "i", element)  +" for i in " + paramName + "]"
+			return "util.python_list_to_java([" + convParam("i", element)  +" for i in " + paramName + "])"
         } else if (kind == CLASS_SET) {
 			var element = type.args[0];
-			return "set([" + convParam(overloaded, "i", element)  +" for i in " + paramName + "])"
+			return "util.python_set_to_java(set([" + convParam("i", element)  +" for i in " + paramName + "]))"
 		} else if (kind == CLASS_OBJECT) {
 			return "util.python_to_java(" + paramName + ")";
+		} else if (kind == CLASS_MAP) {
+		    var keyType = type.args[0];
+            var valueType = type.args[1];
+			return "util.python_map_to_java({" + convParam("k", keyType) + ":" + convParam("v", valueType) +
+                    " for k,v in  iteritems(" + paramName + ")})";
 		} else if (kind.basic || typeName.equals("java.lang.Void")) {
 			return paramName;
 		} else {
@@ -259,7 +262,7 @@
 @comment{"========================"}
 
 @declare{'genMethod'}
-	@code{methodList = methodsByName.get(methodName); overloaded = methodList.size() > 1; method = methodList.get(0);}
+	@code{methodList = methodsByName.get(methodName);  method = methodList.get(0);}
 
 
 	@code{requiredParams = []; optionalParams = []; optionsParam = null; paramNames = []; cnt = 0;}
@@ -423,7 +426,7 @@
 
 @code{handlers = []}
 @declare{'genHandlers'}
-	@code{methodList = methodsByName.get(methodName); overloaded = methodList.size() > 1; method = methodList.get(0);}
+	@code{methodList = methodsByName.get(methodName);  method = methodList.get(0);}
 	@foreach{method: methodList}
 		@foreach{param: method.params}
 			@if{param.type.kind == CLASS_HANDLER && !handlers.contains(param.type.name)}
@@ -492,7 +495,7 @@
 
 from __future__ import unicode_literals, print_function, absolute_import\n
 from vertx_python import util\n
-from vertx_python.compat import long, basestring\n
+from vertx_python.compat import long, basestring, iteritems\n
 \n
 
 @comment{"Initalize the Vert.x client if necessary"}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -46,7 +46,7 @@
 }
 
 @declare{'genMethodCall'}
-@if{static}util.jvm.@{ifaceFQCN}@else{}self.j@{ifaceName}@end{}.@{method.name}(
+@if{static}util.jvm.@{ifacePackageName}.@{ifaceSimpleName}@else{}self.j@{ifaceName}@end{}.@{method.name}(
 	@foreach{param: method.params}
 		@code{argName=convertName(param.name);}
 		@includeNamed{'convParam'}
@@ -352,7 +352,7 @@ result.result()
 					            self.handler(None, result.cause())\n
 				@else{}
 					@if{param.type.args[0].name.startsWith('java.lang.Void')}
-								self.handler(None)\n
+					                self.handler(None)\n
 					@else{}
 					        self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=param.type.args[0]})\n
 					@end{}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -12,9 +12,7 @@
 		}
 		return false;
 	}
-}
 
-@code{
 	def getAllParamNames(methods) {
 		paramNames = [];
 		for (method : methods) {
@@ -26,9 +24,7 @@
 		}
 		return paramNames;
 	}
-}
 
-@code{
 	def getParamNames(method) {
 		paramNames = [];
 		for (param : method.params) {
@@ -36,130 +32,149 @@
 		}
 		return paramNames;
 	}
-}
 
-@code{
 	def convertName(name) {
 		reserved = ['if', 'elif', 'else', 'from', 'in', 'int', 'bool', 'long', 'bytes', 'str', 'unicode', 'not', 'and', 'or', 'as', 'try', 'except', 'raise', 'return', 'lambda', 'finally', 'continue', 'for', 'while', 'yield', 'pass', 'with', 'assert', 'break', 'class', 'def', 'exec', 'del', 'import'];
 		return reserved.contains(name) ? helper.convertCamelCaseToUnderscores('_' + name) : helper.convertCamelCaseToUnderscores(name);
 	}
+
+	def genMethodCall(method) {
+		out = "";
+		if (static) {
+			out += "util.jvm" + ifacePackageName + "." + ifaceSimpleName;
+		} else {
+			out += "self.j" + ifaceName;
+		}
+		out += "." + method.name + "(";
+		for (param : method.params) {
+			if (param != method.params[0]) {
+				out += ", ";
+			}
+			argName = convertName(param.name);
+			out += convParam(overloaded, argName, param.type);
+		}
+		out += ")";
+		return out;	
+	}
+
+	/*
+     * Generate the code that converts a Java return to the corresponding Python value.
+     * This is also used for converting values returned from Java API via handlers.
+     */
+	def convReturn(type, expr) {
+		var kind = type.kind;
+		if (kind == CLASS_LIST) {
+			var elementType = type.args[0];
+			return "[" + convReturn(elementType, "elt") + " for elt in " + expr + "]";
+		} else if (kind == CLASS_SET) {
+			var elementType = type.args[0];
+			return "set([" + convReturn(elementType, "elt") + " for elt in " + expr + "])";
+		} else if (kind == CLASS_JSON_OBJECT) {
+			return "util.java_to_python(" + expr + ")";
+		} else if (kind == CLASS_JSON_ARRAY) {
+			return "util.java_to_python(" + expr + ")";
+		} else if (kind == CLASS_DATA_OBJECT) {
+			return "util.data_object_to_json(" + expr + ")";
+		} else if (kind == CLASS_API) {
+			if (type.raw != null) {
+				if (type.raw.simpleName.equals("Throwable")) {
+					return "util.java_to_python(" + expr + ")";
+				} else {
+					return type.raw.simpleName + "(" + expr + ")";
+				}
+			} else {
+				return "util.java_to_python(" + expr ")";
+			}
+		} else if (kind.basic) {
+			var typeName = type.name;
+			if (typeName == 'char' || typeName == 'java.lang.Character') {
+				return expr;
+			} else if (typeName == 'long' || typeName == 'java.lang.Long') {
+				return expr;
+			} else if (typeName == 'byte' || typeName == 'java.lang.Byte') {
+				return expr;
+			} else if (typeName == 'short' || typeName == 'java.lang.Short') {
+				return expr;
+			} else if (typeName == 'float' || typeName == 'java.lang.Float') {
+				return expr;
+			} else if (typeName == 'double' || typeName == 'java.lang.Double') {
+				return expr;
+			} else {
+				return expr;
+			}
+		}
+		return "util.java_to_python(" + expr + ")";
+	}
+
+	/*
+     * Generate the code that converts a parameter from Python to Java to 
+     * call a Java API method.
+	 */
+	def getHandlerName(type) {
+		if (type.kind == CLASS_LIST || type.kind == CLASS_SET) {
+			var elem = type.args[0];
+			var elemname = getHandlerName(elem);
+		} else {
+			var elemname = "";
+		}
+		if (type.raw != null) {
+			return type.raw.simpleName + elemname;
+		} else {
+			return type.name + elemname;
+		}
+	}
+
+	def convParam(overloaded, argName, type) {
+		var paramName = argName;
+		var kind = type.kind;
+		var typeName = type.name;
+		if (kind == CLASS_HANDLER) {
+			var element = type.args[0];
+			if (element.kind == CLASS_ASYNC_RESULT) {
+				var innerarg = element.args[0];
+				return "Async" + getHandlerName(innerarg) + "Handler(" + convertName(paramName) + ")";
+			} else {
+				return getHandlerName(element) + "Handler(" + convertName(paramName) + ")";
+            }
+		} else if (kind == CLASS_JSON_OBJECT) {
+			return "util.dict_to_json(" + convertName(paramName) + ")";
+        } else if (kind == CLASS_JSON_ARRAY) {
+			return "util.list_to_json(" + convertName(paramName) + ")";
+        } else if (kind == CLASS_DATA_OBJECT) {
+			return type.simpleName + "(util.dict_to_json(" + convertName(paramName) + ")" + 
+                   " if " + convertName(paramName) + " is not None else None)";
+
+        } else if (kind.basic) {
+			if (typeName == 'char' || typeName == 'java.lang.Character') {
+				return "util.convert_char(" + convertName(paramName) + ")";
+			} else if (typeName == 'long' || typeName == 'java.lang.Long') {
+				return "util.convert_long_to_java(" + convertName(paramName) + ")";
+			} else if (typeName == 'byte' || typeName == 'java.lang.Byte') {
+				return "util.convert_byte_to_java(" + convertName(paramName) + ")";
+			} else if (typeName == 'short' || typeName == 'java.lang.Short') {
+				return "util.convert_short_to_java(" + convertName(paramName) + ")";
+			} else if (typeName == 'float' || typeName == 'java.lang.Float') {
+				return "util.convert_float_to_java(" + convertName(paramName) + ")";
+			} else if (typeName == 'double' || typeName == 'java.lang.Double') {
+				return "util.convert_double_to_java(" + convertName(paramName) + ")";
+			} else {
+				return convertName(paramName);
+			}
+        } else if (kind == CLASS_LIST) {
+			var element = type.args[0];
+			return "[" + convParam(overloaded, "i", element)  +" for i in " + paramName + "]"
+        } else if (kind == CLASS_SET) {
+			var element = type.args[0];
+			return "set([" + convParam(overloaded, "i", element)  +" for i in " + paramName + "])"
+		} else if (kind == CLASS_OBJECT) {
+			return "util.python_to_java(" + paramName + ")";
+		} else if (kind.basic || typeName.equals("java.lang.Void")) {
+			return paramName;
+		} else {
+			return paramName + "._jdel()";
+        }
+	}
 }
-
-@declare{'genMethodCall'}
-@if{static}util.jvm.@{ifacePackageName}.@{ifaceSimpleName}@else{}self.j@{ifaceName}@end{}.@{method.name}(
-	@foreach{param: method.params}
-		@code{argName=convertName(param.name);}
-		@includeNamed{'convParam'}
-	@end{", "})
-@end{}
-
-@comment{"Generate the code that converts a parameter from Python to Java to call a Java API method"}
-@comment{"============================================================================================="}
-
-@declare{'convParam'}
-	@code{paramName = overloaded ? argName : param.name;}
-	@if{param.type.kind == CLASS_HANDLER}
-		@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
-			@if{param.type.args[0].args[0].raw != null}
-				Async@{param.type.args[0].args[0].raw.simpleName}Handler(@{convertName(paramName)})
-			@else{}
-				Async@{param.type.args[0].args[0].name}Handler(@{convertName(paramName)})
-			@end{}
-		@else{}
-			@if{param.type.args[0].raw != null}
-				@{param.type.args[0].raw.simpleName}Handler(@{convertName(paramName)})
-			@else{}
-				@{param.type.args[0].name}Handler(@{convertName(paramName)})
-			@end{}
-		@end{}
-	@else{param.type.kind == CLASS_JSON_OBJECT}
-		util.dict_to_json(@{convertName(paramName)})
-	@else{param.type.kind == CLASS_JSON_ARRAY}
-		util.list_to_json(@{convertName(paramName)})
-	@else{param.dataObject}
-		@{param.type.simpleName}(util.dict_to_json(@{convertName(paramName)})) if @{convertName(paramName)} is not None else None
-	@else{param.type.name == 'char' || param.type.name == 'java.lang.Character'}
-		util.convert_char(@{convertName(paramName)})
-	@else{param.type.name == 'long' || param.type.name == 'java.lang.Long'}
-		util.convert_long_to_java(@{convertName(paramName)})
-	@else{param.type.name == 'byte' || param.type.name == 'java.lang.Byte'}
-		util.convert_byte_to_java(@{convertName(paramName)})
-	@else{param.type.name == 'short' || param.type.name == 'java.lang.Short'}
-		util.convert_short_to_java(@{convertName(paramName)})
-	@else{param.type.name == 'float' || param.type.name == 'java.lang.Float'}
-		util.convert_float_to_java(@{convertName(paramName)})
-	@else{param.type.name == 'double' || param.type.name == 'java.lang.Double'}
-		util.convert_double_to_java(@{convertName(paramName)})
-	@else{param.type.kind == CLASS_LIST}
-		@if{param.type.args[0].name == 'char' || param.type.args[0].name == 'java.lang.Character'}
-			util.convert_char(@{convertName(paramName)})
-		@else{param.type.args[0].name == 'long' || param.type.args[0].name == 'java.lang.Long'}
-			util.convert_long_list_to_java(@{convertName(paramName)})
-		@else{param.type.args[0].name == 'byte' || param.type.args[0].name == 'java.lang.Byte'}
-			util.convert_byte_list_to_java(@{convertName(paramName)})
-		@else{param.type.args[0].name == 'short' || param.type.args[0].name == 'java.lang.Short'}
-			util.convert_short_list_to_java(@{convertName(paramName)})
-		@else{param.type.args[0].name == 'float' || param.type.args[0].name == 'java.lang.Float'}
-			util.convert_float_list_to_java(@{convertName(paramName)})
-		@else{param.type.args[0].name == 'double' || param.type.args[0].name == 'java.lang.Double'}
-			util.convert_double_list_to_java(@{convertName(paramName)})
-		@else{}
-			util.python_to_java(@{convertName(paramName)})
-		@end{}
-	@else{param.type.kind == CLASS_OBJECT}
-		util.python_to_java(@{convertName(paramName)})
-	@else{param.type.kind.basic || param.type.name.equals("java.lang.Void")}
-		@{convertName(paramName)}
-	@else{}
-		@{convertName(paramName)}._jdel()
-	@end{}
-@end{}
-
-@declare{'resultVal'}
-result
-@end{}
-
-@declare{'arVal'}
-result.result()
-@end{}
-
-@comment{"Generate the code that converts a Java return to the corresponding Python value"}
-@comment{"This is also used for converting values returned from Java API via handlers"}
-@comment{"==================================================================================="}
-
-@declare{'convReturn'}
-	@if{returnType.kind == CLASS_LIST || returnType.kind == CLASS_SET}
-		@code{elementType=returnType.args[0]}
-		@if{elementType.kind == CLASS_JSON_OBJECT}
-			util.list_obj_to_python(@includeNamed{templ}, dict)
-		@else{elementType.kind == CLASS_JSON_ARRAY}
-			util.list_obj_to_python(@includeNamed{templ}, list)
-		@else{elementType.kind == CLASS_API}
-			util.list_obj_to_python(@includeNamed{templ}, @{elementType.raw.simpleName})
-		@else{}
-			@includeNamed{templ}
-		@end{}
-	@else{returnType.kind == CLASS_JSON_OBJECT || returnType.kind == CLASS_JSON_ARRAY}
-		util.java_to_python(@includeNamed{templ})
-	@else{returnType.kind.basic || returnType.name.equals('void')}
-		@includeNamed{templ}
-	@else{returnType.kind == CLASS_DATA_OBJECT}
-		util.data_object_to_json(@includeNamed{templ})
-	@else{returnType.kind == CLASS_API}
-		@if{returnType.raw != null}
-			@if{returnType.raw.simpleName.equals("Throwable")}
-				util.java_to_python(@includeNamed{templ})
-			@else{}
-				@{returnType.raw.simpleName}(@includeNamed{templ})
-			@end{}
-		@else{}
-			util.java_to_python(@includeNamed{templ})
-		@end{}
-	@else{}
-		@comment{'This will probably happen if the return type is generic'}
-		util.java_to_python(@includeNamed{templ})
-	@end{}
-@end{}
 
 @comment{"Generate a Python condition"}
 @comment{"==========================="}
@@ -310,17 +325,17 @@ result.result()
 			@if{requiresTypeCheck([baseMethod])}
 				@{ind}    if @includeNamed{'genCondition';method=baseMethod;}:\n
 				@if{baseMethod.fluent}
-					@{ind}        @includeNamed{'genMethodCall'; method=baseMethod}\n
+					@{ind}        @{genMethodCall(baseMethod)}\n
 				@else{}
-					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType; method=baseMethod}\n
+					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod))}\n
 				@end{}
 				@{ind}    else:\n
 				@{ind}        raise TypeError("Invalid arguments for @{convertName(methodName)}")\n
 			@else{}
 				@if{baseMethod.fluent}
-					@{ind}    @includeNamed{'genMethodCall'; method=baseMethod}\n
+					@{ind}    @{genMethodCall(baseMethod)}\n
 				@else{}
-					@{ind}    return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType; method=baseMethod}\n
+					@{ind}    return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod))}\n
 				@end{}
 			@end{}
 		@else{}
@@ -328,26 +343,26 @@ result.result()
 			@foreach{method: childMethods}
 				@{ind}    @if{mcnt == 0}if @code{mcnt++}@else{}elif @end{}@includeNamed{'genCondition'}:\n
 				@if{method.fluent}
-					@{ind}        @includeNamed{'genMethodCall'}\n
+					@{ind}        @{genMethodCall(method)}\n
 				@else{}
-					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=method.returnType}\n
+					@{ind}        return @{convReturn(method.returnType, genMethodCall(method))}\n
 				@end{}
 			@end{}
 			@if{requiresTypeCheck([baseMethod])}
 				@{ind}    elif @includeNamed{'genCondition';method=baseMethod;}:\n
 				@if{baseMethod.fluent}
-					@{ind}        @includeNamed{'genMethodCall'; method=baseMethod}\n
+					@{ind}        @{genMethodCall(baseMethod)}\n
 				@else{}
-					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType; method=baseMethod}\n
+					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod))}\n
 				@end{}
 				@{ind}    else:\n
 				@{ind}        raise TypeError("Invalid arguments for @{convertName(methodName)}")\n
 			@else{}
 				@{ind}    else:\n
 				@if{baseMethod.fluent}
-					@{ind}        @includeNamed{'genMethodCall'; method=baseMethod}\n
+					@{ind}        @{genMethodCall(baseMethod)}\n
 				@else{}
-					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType; method=baseMethod}\n
+					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod))}\n
 				@end{}
 			@end{}
 			@if{baseMethod.fluent}
@@ -362,55 +377,50 @@ result.result()
 @comment{"========================="}
 
 @code{handlers = []}
-
 @declare{'genHandlers'}
 	@code{methodList = methodsByName.get(methodName); overloaded = methodList.size() > 1; method = methodList.get(0);}
 	@foreach{method: methodList}
 		@foreach{param: method.params}
 			@if{param.type.kind == CLASS_HANDLER && !handlers.contains(param.type.name)}
-				@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
-					@if{param.type.args[0].args[0].raw != null}
-						@code{className = 'Async' + param.type.args[0].args[0].raw.simpleName + 'Handler'}
+				@if{param.type.kind == CLASS_HANDLER}
+					@code{element = param.type.args[0]}
+					@if{element.kind == CLASS_ASYNC_RESULT}
+						@code{className = 'Async' + getHandlerName(element.args[0]) + 'Handler'}
 					@else{}
-						@code{className = 'Async' + param.type.args[0].args[0].name + 'Handler'}
+						@code{className = getHandlerName(element) + 'Handler'}
 					@end{}
-				@else{}
-					@if{param.type.args[0].raw != null}
-						@code{className = param.type.args[0].raw.simpleName + 'Handler'}
-					@else{}
-						@code{className = param.type.args[0].name + 'Handler'}
+					@if{!handlers.contains(className)}
+						@code{handlers.add(className)}
+						class @{className}(object):\n
+						    class Java:\n
+						        implements = ['io.vertx.core.Handler']\n
+						    def __init__(self, handler):\n
+						        self.handler = handler\n
+						    def handle(self, result):\n
+						        try:\n
+							@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
+						            if result.succeeded():\n
+								@if{param.type.args[0].args[0].name.startsWith('java.lang.Void')}
+						                self.handler(None, None)\n
+								@else{}
+						                self.handler(@{convReturn(param.type.args[0].args[0], "result.result()")}, None)\n
+								@end{}
+						            else:\n
+						                self.handler(None, result.cause())\n
+							@else{}
+								@if{param.type.args[0].name.startsWith('java.lang.Void')}
+						            self.handler(None)\n
+								@else{}
+						            self.handler(@{convReturn(param.type.args[0], "result")})\n
+								@end{}
+							@end{}
+						        except Exception:\n
+						            import traceback\n
+						            traceback.print_exc()\n
+						            raise\n
+						\n
 					@end{}
 				@end{}
-				class @{className}(object):\n
-				    class Java:\n
-				        implements = ['io.vertx.core.Handler']\n
-				    def __init__(self, handler):\n
-				        self.handler = handler\n
-				    def handle(self, result):\n
-				        try:\n
-					@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
-				            if result.succeeded():\n
-						@if{param.type.args[0].args[0].name.startsWith('java.lang.Void')}
-				                self.handler(None, None)\n
-						@else{}
-				                self.handler(@includeNamed{'convReturn'; templ='arVal'; returnType=param.type.args[0].args[0]}, None)\n
-						@end{}
-				            else:\n
-				                self.handler(None, result.cause())\n
-					@else{}
-						@if{param.type.args[0].name.startsWith('java.lang.Void')}
-				            self.handler(None)\n
-						@else{}
-				            self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=param.type.args[0]})\n
-						@end{}
-					@end{}
-				        except Exception:\n
-				            import traceback\n
-				            traceback.print_exc()\n
-				            raise\n
-				
-				\n
-				@code{handlers.add(param.type.name)}
 			@end{}
 		@end{}
 	@end{}
@@ -505,7 +515,7 @@ class @{ifaceSimpleName}(@foreach{superType: superTypes}@{superType.raw.simpleNa
 @end{}
 
 @comment{"Iterate through methods again and create result handler classes"}
-
 @foreach{methodName:methodsByName.keySet()}
 	@includeNamed{'genHandlers'}
 @end{}
+

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -323,7 +323,7 @@ result.result()
 				    def handle(self, result):\n
 				@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
 					        if result.succeeded():\n
-					@if{param.type.args[0].name.startsWith('java.lang.Void')}
+					@if{param.type.args[0].args[0].name.startsWith('java.lang.Void')}
 						            self.handler(None, None)\n
 					@else{}
 						            self.handler(@includeNamed{'convReturn'; templ='arVal'; returnType=param.type.args[0].args[0]}, None)\n

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -245,6 +245,8 @@
 		@else{param.type.kind == CLASS_DATA_OBJECT}
 			True
 			@comment{"len(@{convertName(param.name)}) > 0"}
+		@else{param.type.kind == CLASS_API}
+			@{convertName(param.name)} is not None
 		@else{}
 			@comment{"Don't check anything, since None might be allowed."}
 			True
@@ -406,9 +408,9 @@
 					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod), false)}\n
 				@end{}
 			@end{}
-			@if{baseMethod.fluent}
-				        return @if{static}@{ifaceSimpleName}@else{}self@end{}\n
-			@end{}
+		@end{}
+		@if{baseMethod.fluent}
+			        return @if{static}@{ifaceSimpleName}@else{}self@end{}\n
 		@end{}
 		\n
 	@end{}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -103,6 +103,9 @@
 			} else {
 				return "util.java_to_python(" + expr ")";
 			}
+		} else if (kind == CLASS_ENUM) {
+			System.out.println("HEY HEY HEY HEY " +type.name);
+			return expr + ".toString()";
 		} else if (kind.basic) {
 			var typeName = type.name;
 			if (typeName == 'char' || typeName == 'java.lang.Character') {
@@ -193,6 +196,8 @@
             var valueType = type.args[1];
 			return "util.python_map_to_java({" + convParam("k", keyType) + ":" + convParam("v", valueType) +
                     " for k,v in  iteritems(" + paramName + ")})";
+		} else if (kind == CLASS_ENUM) {
+			return "util.jvm." + type.name + ".valueOf(" + paramName + ")";
 		} else if (kind.basic || typeName.equals("java.lang.Void")) {
 			return paramName;
 		} else {

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -80,9 +80,34 @@
 		@{param.type.simpleName}(util.dict_to_json(@{convertName(paramName)})) if @{convertName(paramName)} is not None else None
 	@else{param.type.name == 'char' || param.type.name == 'java.lang.Character'}
 		util.convert_char(@{convertName(paramName)})
+	@else{param.type.name == 'long' || param.type.name == 'java.lang.Long'}
+		util.convert_long_to_java(@{convertName(paramName)})
+	@else{param.type.name == 'byte' || param.type.name == 'java.lang.Byte'}
+		util.convert_byte_to_java(@{convertName(paramName)})
+	@else{param.type.name == 'short' || param.type.name == 'java.lang.Short'}
+		util.convert_short_to_java(@{convertName(paramName)})
+	@else{param.type.name == 'float' || param.type.name == 'java.lang.Float'}
+		util.convert_float_to_java(@{convertName(paramName)})
+	@else{param.type.name == 'double' || param.type.name == 'java.lang.Double'}
+		util.convert_double_to_java(@{convertName(paramName)})
+	@else{param.type.kind == CLASS_LIST}
+		@if{param.type.args[0].name == 'char' || param.type.args[0].name == 'java.lang.Character'}
+			util.convert_char(@{convertName(paramName)})
+		@else{param.type.args[0].name == 'long' || param.type.args[0].name == 'java.lang.Long'}
+			util.convert_long_list_to_java(@{convertName(paramName)})
+		@else{param.type.args[0].name == 'byte' || param.type.args[0].name == 'java.lang.Byte'}
+			util.convert_byte_list_to_java(@{convertName(paramName)})
+		@else{param.type.args[0].name == 'short' || param.type.args[0].name == 'java.lang.Short'}
+			util.convert_short_list_to_java(@{convertName(paramName)})
+		@else{param.type.args[0].name == 'float' || param.type.args[0].name == 'java.lang.Float'}
+			util.convert_float_list_to_java(@{convertName(paramName)})
+		@else{param.type.args[0].name == 'double' || param.type.args[0].name == 'java.lang.Double'}
+			util.convert_double_list_to_java(@{convertName(paramName)})
+		@else{}
+			util.python_to_java(@{convertName(paramName)})
+		@end{}
 	@else{param.type.kind == CLASS_OBJECT}
 		util.python_to_java(@{convertName(paramName)})
-	@else{param.type.kind == CLASS_OBJECT}
 	@else{param.type.kind.basic || param.type.name.equals("java.lang.Void")}
 		@{convertName(paramName)}
 	@else{}
@@ -277,7 +302,7 @@ result.result()
 				@code{refedType = retType.raw.name}
 				@code{refedPackage = refedType.substring(refedType.lastIndexOf('.', refedType.lastIndexOf('.') - 1) + 1, 
                                                          refedType.lastIndexOf('.'))}
-				@{ind}from @{retType.moduleName}_python.@{refedPackage}.@{convertName(retType.simpleName)} import @{retType.simpleName}\n
+				@{ind}    from @{retType.moduleName}_python.@{refedPackage}.@{convertName(retType.simpleName)} import @{retType.simpleName}\n
 				@code{imported.add(retType.simpleName)}
 			@end{}
 			@if{requiresTypeCheck([baseMethod])}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -67,13 +67,13 @@
 			@{param.type.args[0].raw.simpleName}Handler(@{convertName(paramName)})
 		@end{}
 	@else{param.type.kind == CLASS_JSON_OBJECT}
-		util.dict_to_json(@{paramName})
+		util.dict_to_json(@{convertName(paramName)})
 	@else{param.type.kind == CLASS_JSON_ARRAY}
-		util.list_to_json(@{paramName})
+		util.list_to_json(@{convertName(paramName)})
 	@else{param.dataObject}
-		@{param.type.simpleName}.optionsFromJson(util.dict_to_json(@{paramName})) if @{paramName} is not None else None
+		@{param.type.simpleName}.optionsFromJson(util.dict_to_json(@{convertName(paramName)})) if @{convertName(paramName)} is not None else None
 	@else{param.type.kind == CLASS_OBJECT}
-		util.python_to_java(@{paramName})
+		util.python_to_java(@{convertName(paramName)})
 	@else{param.type.kind.basic || param.type.name.equals("java.lang.Void")}
 		@{convertName(paramName)}
 	@else{}
@@ -335,6 +335,7 @@ result.result()
 							self.handler(None)\n
 					@else{}
 					        self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=param.type.args[0]})\n
+					@end{}
 				@end{}
 				\n
 				@code{handlers.add(param.type.name)}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -141,6 +141,10 @@ result.result()
 		@end{}
 	@else{returnType.kind == CLASS_JSON_OBJECT || returnType.kind == CLASS_JSON_ARRAY}
 		util.java_to_python(@includeNamed{templ})
+	@else{returnType.kind.basic || returnType.name.equals('void')}
+		@includeNamed{templ}
+	@else{returnType.kind == CLASS_DATA_OBJECT}
+		util.data_object_to_json(@includeNamed{templ})
 	@else{returnType.kind == CLASS_API}
 		@if{returnType.raw != null}
 			@if{returnType.raw.simpleName.equals("Throwable")}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -156,7 +156,7 @@
 			return "util.list_to_json(" + convertName(paramName) + ")";
         } else if (kind == CLASS_DATA_OBJECT) {
 			return type.simpleName + "(util.dict_to_json(" + convertName(paramName) + "))" + 
-                   " if " + convertName(paramName) + " else None";
+                   " if " + convertName(paramName) + " is not None else None";
 
         } else if (kind.basic) {
 			if (typeName == 'char' || typeName == 'java.lang.Character') {

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -115,11 +115,15 @@ result.result()
 		@end{}
 	@else{returnType.kind == CLASS_JSON_OBJECT || returnType.kind == CLASS_JSON_ARRAY}
 		util.java_to_python(@includeNamed{templ})
-	@else{returnType.kind.basic || returnType.equals('java.lang.Void')}
+	@else{returnType.kind.basic || returnType.name.equals('void')}
 		@includeNamed{templ}
 	@else{method.returnType.kind == CLASS_API}
 		@if{returnType.raw != null}
-			@{returnType.raw.simpleName}(@includeNamed{templ})
+			@if{returnType.kind == CLASS_THROWABLE}
+				util.java_to_python(@includeNamed{templ})
+			@else{}
+				@{returnType.raw.simpleName}(@includeNamed{templ})
+			@end{}
 		@else{}
 			util.java_to_python(@includeNamed{templ})
 		@end{}
@@ -160,7 +164,7 @@ result.result()
 				param.type.name == 'double' || param.type.name == 'java.lang.Double'}
 				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, float)
 			@else{param.type.name == 'byte' || param.type.name == 'java.lang.Byte'}
-				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, byte)
+				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, bytes)
 			@else{param.type.name == 'boolean' || param.type.name == 'java.lang.Boolean'}
 				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, bool)
 			@else{param.type.name == 'char' || param.type.name == 'java.lang.Character'}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -117,9 +117,9 @@ result.result()
 		util.java_to_python(@includeNamed{templ})
 	@else{returnType.kind.basic || returnType.name.equals('void')}
 		@includeNamed{templ}
-	@else{method.returnType.kind == CLASS_API}
+	@else{returnType.kind == CLASS_API}
 		@if{returnType.raw != null}
-			@if{returnType.kind == CLASS_THROWABLE}
+			@if{returnType.raw.simpleName.equals("Throwable")}
 				util.java_to_python(@includeNamed{templ})
 			@else{}
 				@{returnType.raw.simpleName}(@includeNamed{templ})
@@ -128,7 +128,7 @@ result.result()
 			util.java_to_python(@includeNamed{templ})
 		@end{}
 	@else{}
-	@comment{'This will probably happen if the return type is generic'}
+		@comment{'This will probably happen if the return type is generic'}
 		util.java_to_python(@includeNamed{templ})
 	@end{}
 @end{}
@@ -181,7 +181,8 @@ result.result()
 		@else{param.type.kind == CLASS_DATA_OBJECT}
 			len(@{convertName(param.name)}) > 0
 		@else{}
-			True
+			@comment{"This could possibly be smarter and do an isinstance check sometimes (not always, though)"}
+			@{convertName(param.name)} is not None
 		@end{}
 	@end{" and "}
 @end{}
@@ -397,17 +398,29 @@ util.vertx_init()\n
 
 @comment{"Generate the imports"}
 
+@code{imported = []}
+@foreach{importedType : importedTypes}
+	@code{impType = importedType.raw.name}
+	@if{impType.contains("vertx")}
+	@end{}
+@end{}
+
 @foreach{referencedType : referencedTypes}
 	@code{refedType = referencedType.raw.name}
 	@code{refedPackage = refedType.substring(refedType.lastIndexOf('.', refedType.lastIndexOf('.') - 1) + 1, refedType.lastIndexOf('.'))}
 	from @{referencedType.moduleName}_python.@{refedPackage}.@{convertName(referencedType.simpleName)} import @{referencedType.simpleName}\n
+	@code{imported.add(referencedType.simpleName)}
 @end{}
 \n
 
 @comment{"The top level vars for the module"}
 
+@code{referencedDoTypes = []}
 @foreach{dataObjectType: referencedDataObjectTypes}
-	@{dataObjectType.simpleName} = util.jvm.@{dataObjectType}\n
+	@if{!referencedDoTypes.contains(dataObjectType)}
+		@{dataObjectType.simpleName} = util.jvm.@{dataObjectType}\n
+		@code{referencedDoTypes.add(dataObjectType)}
+	@end{}
 @end{}
 \n
 @code{ifaceName = helper.decapitaliseFirstLetter(ifaceSimpleName)}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -58,13 +58,23 @@
 
 @declare{'convParam'}
 	@code{paramName = overloaded ? argName : param.name;}
+	@code{System.out.println("IN here for " + paramName)}
 	@if{param.type.kind == CLASS_HANDLER}
 		@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
-			Async@{param.type.args[0].args[0].raw.simpleName}Handler(@{convertName(paramName)})
+			@if{param.type.args[0].args[0].raw != null}
+				Async@{param.type.args[0].args[0].raw.simpleName}Handler(@{convertName(paramName)})
+			@else{}
+				Async@{param.type.args[0].args[0].name}Handler(@{convertName(paramName)})
+			@end{}
 		@else{param.type.args[0].name.equals("java.lang.Void")}
 			@{convertName(paramName)}
 		@else{}
-			@{param.type.args[0].raw.simpleName}Handler(@{convertName(paramName)})
+			@if{param.type.args[0].raw != null}
+				@{param.type.args[0].raw.simpleName}Handler(@{convertName(paramName)})
+			@else{}
+				@{param.type.args[0].name}Handler(@{convertName(paramName)})
+			@end{}
+			@code{System.out.println("ELSE is done")}
 		@end{}
 	@else{param.type.kind == CLASS_JSON_OBJECT}
 		util.dict_to_json(@{convertName(paramName)})
@@ -79,6 +89,7 @@
 	@else{}
 		@{convertName(paramName)}._jdel()
 	@end{}
+	@code{System.out.println("DONE here for " + paramName)}
 @end{}
 
 @declare{'resultVal'}
@@ -110,7 +121,11 @@ result.result()
 	@else{returnType.kind.basic || returnType.equals('java.lang.Void')}
 		@includeNamed{templ}
 	@else{method.returnType.kind == CLASS_API}
-		@{returnType.raw.simpleName}(@includeNamed{templ})
+		@if{returnType.raw != null}
+			@{returnType.raw.simpleName}(@includeNamed{templ})
+		@else{}
+			util.java_to_python(@includeNamed{templ})
+		@end{}
 	@else{}
 	@comment{'This will probably happen if the return type is generic'}
 		util.java_to_python(@includeNamed{templ})
@@ -309,11 +324,19 @@ result.result()
 	@code{methodList = methodsByName.get(methodName); overloaded = methodList.size() > 1; method = methodList.get(0);}
 	@foreach{method: methodList}
 		@foreach{param: method.params}
-			@if{param.type.name.startsWith('io.vertx.core.Handler<') && !handlers.contains(param.type.name)}
+			@if{param.type.kind == CLASS_HANDLER && !handlers.contains(param.type.name)}
 				@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
-					@code{className = 'Async' + param.type.args[0].args[0].raw.simpleName + 'Handler'}
+					@if{param.type.args[0].args[0].raw != null}
+						@code{className = 'Async' + param.type.args[0].args[0].raw.simpleName + 'Handler'}
+					@else{}
+						@code{className = 'Async' + param.type.args[0].args[0].name + 'Handler'}
+					@end{}
 				@else{}
-					@code{className = param.type.args[0].raw.simpleName + 'Handler'}
+					@if{param.type.args[0].raw != null}
+						@code{className = param.type.args[0].raw.simpleName + 'Handler'}
+					@else{}
+						@code{className = param.type.args[0].name + 'Handler'}
+					@end{}
 				@end{}
 				class @{className}(object):\n
 				    class Java:\n
@@ -332,7 +355,7 @@ result.result()
 					            self.handler(None, result.cause())\n
 				@else{}
 					@if{param.type.args[0].name.startsWith('java.lang.Void')}
-							self.handler(None)\n
+								self.handler(None)\n
 					@else{}
 					        self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=param.type.args[0]})\n
 					@end{}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -58,7 +58,6 @@
 
 @declare{'convParam'}
 	@code{paramName = overloaded ? argName : param.name;}
-	@code{System.out.println("IN here for " + paramName)}
 	@if{param.type.kind == CLASS_HANDLER}
 		@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
 			@if{param.type.args[0].args[0].raw != null}
@@ -74,7 +73,6 @@
 			@else{}
 				@{param.type.args[0].name}Handler(@{convertName(paramName)})
 			@end{}
-			@code{System.out.println("ELSE is done")}
 		@end{}
 	@else{param.type.kind == CLASS_JSON_OBJECT}
 		util.dict_to_json(@{convertName(paramName)})
@@ -89,7 +87,6 @@
 	@else{}
 		@{convertName(paramName)}._jdel()
 	@end{}
-	@code{System.out.println("DONE here for " + paramName)}
 @end{}
 
 @declare{'resultVal'}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -40,7 +40,7 @@
 
 @code{
 	def convertName(name) {
-		reserved = ['if', 'elif', 'else', 'from', 'in', 'not', 'and', 'or', 'as', 'try', 'except', 'raise', 'return', 'lambda', 'finally', 'continue', 'for', 'while', 'yield', 'pass', 'with', 'assert', 'break', 'class', 'def', 'exec', 'del', 'import'];
+		reserved = ['if', 'elif', 'else', 'from', 'in', 'int', 'bool', 'long', 'bytes', 'str', 'unicode', 'not', 'and', 'or', 'as', 'try', 'except', 'raise', 'return', 'lambda', 'finally', 'continue', 'for', 'while', 'yield', 'pass', 'with', 'assert', 'break', 'class', 'def', 'exec', 'del', 'import'];
 		return reserved.contains(name) ? helper.convertCamelCaseToUnderscores('_' + name) : helper.convertCamelCaseToUnderscores(name);
 	}
 }
@@ -78,8 +78,11 @@
 		util.list_to_json(@{convertName(paramName)})
 	@else{param.dataObject}
 		@{param.type.simpleName}(util.dict_to_json(@{convertName(paramName)})) if @{convertName(paramName)} is not None else None
+	@else{param.type.name == 'char' || param.type.name == 'java.lang.Character'}
+		util.convert_char(@{convertName(paramName)})
 	@else{param.type.kind == CLASS_OBJECT}
 		util.python_to_java(@{convertName(paramName)})
+	@else{param.type.kind == CLASS_OBJECT}
 	@else{param.type.kind.basic || param.type.name.equals("java.lang.Void")}
 		@{convertName(paramName)}
 	@else{}
@@ -166,7 +169,7 @@ result.result()
 			@else{param.type.name == 'boolean' || param.type.name == 'java.lang.Boolean'}
 				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, bool)
 			@else{param.type.name == 'char' || param.type.name == 'java.lang.Character'}
-				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, basestring)
+				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, (basestring, int))
 			@end{}
 		@else{param.type.kind == CLASS_STRING}
 			@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, basestring)
@@ -265,6 +268,18 @@ result.result()
 		@end{}
 
 		@if{childMethods.isEmpty()}
+			@comment{"Import the Python return type inside of the method if its not "}
+			@comment{"already imported. Needed to avoid circular imports."}
+			@if{baseMethod.returnType.kind == CLASS_API && 
+               !imported.contains(baseMethod.returnType.raw.simpleName) && 
+               baseMethod.returnType.raw.simpleName != ifaceSimpleName}
+				@code{retType = baseMethod.returnType}
+				@code{refedType = retType.raw.name}
+				@code{refedPackage = refedType.substring(refedType.lastIndexOf('.', refedType.lastIndexOf('.') - 1) + 1, 
+                                                         refedType.lastIndexOf('.'))}
+				@{ind}from @{retType.moduleName}_python.@{refedPackage}.@{convertName(retType.simpleName)} import @{retType.simpleName}\n
+				@code{imported.add(retType.simpleName)}
+			@end{}
 			@if{requiresTypeCheck([baseMethod])}
 				@{ind}    if @includeNamed{'genCondition';method=baseMethod;}:\n
 				@if{baseMethod.fluent}
@@ -405,17 +420,6 @@ util.vertx_init()\n
 
 
 @code{imported = []}
-@foreach{importedType : importedTypes}
-	@code{impType = importedType.raw.name}
-	@code{impPackage = impType.substring(impType.lastIndexOf('.', impType.lastIndexOf('.') - 1) + 1, impType.lastIndexOf('.'))}
-	@if{impType.substring(0, impType.lastIndexOf('.')).equals(ifacePackageName)}
-		@if{!referencedDataObjectTypes.contains(importedType) && !importedType.raw.simpleName.equals(ifaceSimpleName)}
-			@comment{"from @{importedType.moduleName}_python.@{impPackage}.@{convertName(importedType.simpleName)} import @{importedType.simpleName}\n"}
-			@comment{"@code{imported.add(importedType.simpleName)}"}
-		@end{}
-	@end{}
-@end{}
-
 @foreach{referencedType : referencedTypes}
 	@if{!imported.contains(referencedType.simpleName)}
 		@code{refedType = referencedType.raw.name}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -60,11 +60,11 @@
 	@code{paramName = overloaded ? argName : param.name;}
 	@if{param.type.kind == CLASS_HANDLER}
 		@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
-			Async@{param.type.args[0].args[0].raw.simpleName}Handler(@{paramName})
-		@else{param.type.args[0].name == "java.lang.Void"}
-			@{paramName}
+			Async@{param.type.args[0].args[0].raw.simpleName}Handler(@{convertName(paramName)})
+		@else{param.type.args[0].name.equals("java.lang.Void")}
+			@{convertName(paramName)}
 		@else{}
-			@{param.type.args[0].raw.simpleName}Handler(@{paramName})
+			@{param.type.args[0].raw.simpleName}Handler(@{convertName(paramName)})
 		@end{}
 	@else{param.type.kind == CLASS_JSON_OBJECT}
 		util.dict_to_json(@{paramName})
@@ -74,10 +74,10 @@
 		@{param.type.simpleName}.optionsFromJson(util.dict_to_json(@{paramName})) if @{paramName} is not None else None
 	@else{param.type.kind == CLASS_OBJECT}
 		util.python_to_java(@{paramName})
-	@else{param.type.kind.basic || param.type.name == "java.lang.Void"}
+	@else{param.type.kind.basic || param.type.name.equals("java.lang.Void")}
 		@{convertName(paramName)}
 	@else{}
-		@{paramName}._jdel()
+		@{convertName(paramName)}._jdel()
 	@end{}
 @end{}
 
@@ -331,6 +331,9 @@ result.result()
 					        else:\n
 					            self.handler(None, result.cause())\n
 				@else{}
+					@if{param.type.args[0].name.startsWith('java.lang.Void')}
+							self.handler(None)\n
+					@else{}
 					        self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=param.type.args[0]})\n
 				@end{}
 				\n

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -90,12 +90,13 @@
 		} else if (kind == CLASS_DATA_OBJECT) {
 			return "util.data_object_to_json(" + expr + ", hashable=" + boolToStr(hashable) + ")";
 		} else if (kind == CLASS_MAP) {
-			var keyType = type.args[0];
-			var valueType = type.args[1];
-			return "{" + convReturn(keyType, "k", hashable) + " : " + 
-                   convReturn(valueType, "v", hashable) + " for k,v in " + expr + ".items()}";
-			
-			return "util.java_map_to_dict(" + expr + ", hashable=" + boolToStr(hashable) + ")";
+			/*
+			*var keyType = type.args[0];
+			*var valueType = type.args[1];
+			*return "{" + convReturn(keyType, "k", hashable) + " : " + 
+            *       convReturn(valueType, "v", hashable) + " for k,v in " + expr + ".items()}";
+			*/
+			return expr;
 		} else if (kind == CLASS_API) {
 			if (type.raw != null) {
 				if (type.raw.simpleName.equals("Throwable")) {
@@ -330,6 +331,7 @@
 	@end{}
 
 	@if{baseMethod != null && static == method.staticMethod}
+		@if{method.cacheReturn}@{ind}@@util.cached\n@end{}
 		@if{static}@{ind}@@classmethod\n@end{}
 		@{ind}def @{convertName(methodName)}(self
 		@foreach{param : requiredParams}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -453,7 +453,9 @@ class @{ifaceSimpleName}(@foreach{superType: superTypes}@{superType.raw.simpleNa
 @comment{"The constructor"}
     def __init__(self, jval):\n
         self.j@{ifaceName} = jval\n
-        super(@{ifaceSimpleName}, self).__init__(@if{superTypes.size() > 0}jval@end{})\n
+		@foreach{superType: superTypes}
+	        @{superType.raw.simpleName}.__init__(self, jval)\n
+		@end{}
 \n
 
 @comment{"Now iterate through each unique method"}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -141,8 +141,8 @@
         } else if (kind == CLASS_JSON_ARRAY) {
 			return "util.list_to_json(" + convertName(paramName) + ")";
         } else if (kind == CLASS_DATA_OBJECT) {
-			return type.simpleName + "(util.dict_to_json(" + convertName(paramName) + ")" + 
-                   " if " + convertName(paramName) + " is not None else None)";
+			return type.simpleName + "(util.dict_to_json(" + convertName(paramName) + "))" + 
+                   " if " + convertName(paramName) + " else None";
 
         } else if (kind.basic) {
 			if (typeName == 'char' || typeName == 'java.lang.Character') {
@@ -171,7 +171,7 @@
 		} else if (kind.basic || typeName.equals("java.lang.Void")) {
 			return paramName;
 		} else {
-			return paramName + "._jdel()";
+			return paramName + "._jdel";
         }
 	}
 }
@@ -225,8 +225,8 @@
 			True
 			@comment{"len(@{convertName(param.name)}) > 0"}
 		@else{}
-			@comment{"This could possibly be smarter and do an isinstance check sometimes (not always, though)"}
-			@{convertName(param.name)} is not None
+			@comment{"Don't check anything, since None might be allowed."}
+			True
 		@end{}
 	@end{" and "}
 @end{}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -41,7 +41,7 @@
 	def genMethodCall(method) {
 		out = "";
 		if (static) {
-			out += "util.jvm" + ifacePackageName + "." + ifaceSimpleName;
+			out += "util.jvm." + ifacePackageName + "." + ifaceSimpleName;
 		} else {
 			out += "self.j" + ifaceName;
 		}
@@ -57,30 +57,44 @@
 		return out;	
 	}
 
+	def boolToStr(b) {
+		return (b) ? "True" : "False";
+    }
+
 	/*
      * Generate the code that converts a Java return to the corresponding Python value.
      * This is also used for converting values returned from Java API via handlers.
      */
-	def convReturn(type, expr) {
+	def convReturn(type, expr, hashable) {
 		var kind = type.kind;
 		if (kind == CLASS_LIST) {
 			var elementType = type.args[0];
-			return "[" + convReturn(elementType, "elt") + " for elt in " + expr + "]";
+			if (hashable) {
+				listtype = "set";
+			} else {
+				listtype = "list";
+			}
+			return listtype + "([" + convReturn(elementType, "elt", hashable) + " for elt in " + expr + "])";
 		} else if (kind == CLASS_SET) {
 			var elementType = type.args[0];
-			return "set([" + convReturn(elementType, "elt") + " for elt in " + expr + "])";
+			if (hashable) {
+				settype = "frozenset";
+			} else {
+				settype = "set";
+			}
+			return settype + "([" + convReturn(elementType, "elt", true) + " for elt in " + expr + "])";
 		} else if (kind == CLASS_JSON_OBJECT) {
-			return "util.java_to_python(" + expr + ")";
+			return "util.java_to_python(" + expr + ", hashable=" + boolToStr(hashable) + ")";
 		} else if (kind == CLASS_JSON_ARRAY) {
-			return "util.java_to_python(" + expr + ")";
+			return "util.java_to_python(" + expr + ", hashable=" + boolToStr(hashable) + ")";
 		} else if (kind == CLASS_DATA_OBJECT) {
-			return "util.data_object_to_json(" + expr + ")";
+			return "util.data_object_to_json(" + expr + ", hashable=" + boolToStr(hashable) + ")";
 		} else if (kind == CLASS_API) {
 			if (type.raw != null) {
 				if (type.raw.simpleName.equals("Throwable")) {
 					return "util.java_to_python(" + expr + ")";
 				} else {
-					return type.raw.simpleName + "(" + expr + ")";
+					return "util.handle_none(" + expr + ", " + type.raw.simpleName + ")";
 				}
 			} else {
 				return "util.java_to_python(" + expr ")";
@@ -103,7 +117,7 @@
 				return expr;
 			}
 		}
-		return "util.java_to_python(" + expr + ")";
+		return "util.java_to_python(" + expr + ", hashable=" + boolToStr(hashable) + ")";
 	}
 
 	/*
@@ -146,7 +160,7 @@
 
         } else if (kind.basic) {
 			if (typeName == 'char' || typeName == 'java.lang.Character') {
-				return "util.convert_char(" + convertName(paramName) + ")";
+				return "util.convert_char_to_java(" + convertName(paramName) + ")";
 			} else if (typeName == 'long' || typeName == 'java.lang.Long') {
 				return "util.convert_long_to_java(" + convertName(paramName) + ")";
 			} else if (typeName == 'byte' || typeName == 'java.lang.Byte') {
@@ -216,7 +230,7 @@
 		@else{param.type.kind == CLASS_STRING}
 			@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, basestring)
 		@else{param.type.kind == CLASS_JSON_OBJECT}
-	    	@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, dict)
+			@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, dict)
 		@else{param.type.kind == CLASS_JSON_ARRAY}
 			@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, (list, tuple))
 		@else{param.type.kind == CLASS_HANDLER}
@@ -327,7 +341,7 @@
 				@if{baseMethod.fluent}
 					@{ind}        @{genMethodCall(baseMethod)}\n
 				@else{}
-					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod))}\n
+					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod), false)}\n
 				@end{}
 				@{ind}    else:\n
 				@{ind}        raise TypeError("Invalid arguments for @{convertName(methodName)}")\n
@@ -335,7 +349,7 @@
 				@if{baseMethod.fluent}
 					@{ind}    @{genMethodCall(baseMethod)}\n
 				@else{}
-					@{ind}    return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod))}\n
+					@{ind}    return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod), false)}\n
 				@end{}
 			@end{}
 		@else{}
@@ -345,7 +359,7 @@
 				@if{method.fluent}
 					@{ind}        @{genMethodCall(method)}\n
 				@else{}
-					@{ind}        return @{convReturn(method.returnType, genMethodCall(method))}\n
+					@{ind}        return @{convReturn(method.returnType, genMethodCall(method), false)}\n
 				@end{}
 			@end{}
 			@if{requiresTypeCheck([baseMethod])}
@@ -353,7 +367,7 @@
 				@if{baseMethod.fluent}
 					@{ind}        @{genMethodCall(baseMethod)}\n
 				@else{}
-					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod))}\n
+					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod), false)}\n
 				@end{}
 				@{ind}    else:\n
 				@{ind}        raise TypeError("Invalid arguments for @{convertName(methodName)}")\n
@@ -362,7 +376,7 @@
 				@if{baseMethod.fluent}
 					@{ind}        @{genMethodCall(baseMethod)}\n
 				@else{}
-					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod))}\n
+					@{ind}        return @{convReturn(baseMethod.returnType, genMethodCall(baseMethod), false)}\n
 				@end{}
 			@end{}
 			@if{baseMethod.fluent}
@@ -403,7 +417,7 @@
 								@if{param.type.args[0].args[0].name.startsWith('java.lang.Void')}
 						                self.handler(None, None)\n
 								@else{}
-						                self.handler(@{convReturn(param.type.args[0].args[0], "result.result()")}, None)\n
+						                self.handler(@{convReturn(param.type.args[0].args[0], "result.result()", false)}, None)\n
 								@end{}
 						            else:\n
 						                self.handler(None, result.cause())\n
@@ -411,7 +425,7 @@
 								@if{param.type.args[0].name.startsWith('java.lang.Void')}
 						            self.handler(None)\n
 								@else{}
-						            self.handler(@{convReturn(param.type.args[0], "result")})\n
+						            self.handler(@{convReturn(param.type.args[0], "result", false)})\n
 								@end{}
 							@end{}
 						        except Exception:\n

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -3,9 +3,10 @@
 
 @code{
 	def requiresTypeCheck(methods) {
+		requiresCheck = [CLASS_PRIMITIVE, CLASS_BOXED_PRIMITIVE, CLASS_STRING, CLASS_JSON_ARRAY, CLASS_JSON_OBJECT, CLASS_HANDLER, CLASS_DATA_OBJECT];
 		for (method : methods) {
 			for (param : method.params) {
-				if ([CLASS_PRIMITIVE, CLASS_BOXED_PRIMITIVE, CLASS_STRING, CLASS_JSON_ARRAY, CLASS_JSON_OBJECT, CLASS_HANDLER, CLASS_DATA_OBJECT].contains(param.type.kind)) {
+				if (requiresCheck.contains(param.type.kind)) {
 					return true;
 				}
 			}
@@ -405,19 +406,17 @@
 			@{ind}    """"""\n
 		@end{}
 
+		@comment{"Import the Python return type inside of the method if its not "}
+		@comment{"already imported. Needed to avoid circular imports."}
+		@if{baseMethod.returnType.kind == CLASS_API && 
+           !imported.contains(baseMethod.returnType.raw.simpleName) && 
+           baseMethod.returnType.raw.simpleName != ifaceSimpleName}
+			@code{refedPackage = baseMethod.returnType.raw.packageName}
+			@code{lastPackage = refedPackage.substring(refedPackage.lastIndexOf('.') + 1)}
+			@code{refedType = baseMethod.returnType.raw.simpleName}
+			@{ind}    from vertx_python.@{lastPackage}.@{convertName(refedType)} import @{refedType}\n
+		@end{}
 		@if{childMethods.isEmpty()}
-			@comment{"Import the Python return type inside of the method if its not "}
-			@comment{"already imported. Needed to avoid circular imports."}
-			@if{baseMethod.returnType.kind == CLASS_API && 
-               !imported.contains(baseMethod.returnType.raw.simpleName) && 
-               baseMethod.returnType.raw.simpleName != ifaceSimpleName}
-				@code{retType = baseMethod.returnType}
-				@code{refedType = retType.raw.name}
-				@code{refedPackage = refedType.substring(refedType.lastIndexOf('.', refedType.lastIndexOf('.') - 1) + 1, 
-                                                         refedType.lastIndexOf('.'))}
-				@{ind}    from @{retType.moduleName}_python.@{refedPackage}.@{convertName(retType.simpleName)} import @{retType.simpleName}\n
-				@code{imported.add(retType.simpleName)}
-			@end{}
 			@if{requiresTypeCheck([baseMethod])}
 				@{ind}    if @includeNamed{'genCondition';method=baseMethod;}:\n
 				@if{baseMethod.fluent}
@@ -553,11 +552,12 @@ util.vertx_init()\n
 
 
 @code{imported = []}
-@foreach{referencedType : referencedTypes}
+@foreach{referencedType : superTypes}
 	@if{!imported.contains(referencedType.simpleName)}
-		@code{refedType = referencedType.raw.name}
-		@code{refedPackage = refedType.substring(refedType.lastIndexOf('.', refedType.lastIndexOf('.') - 1) + 1, refedType.lastIndexOf('.'))}
-		from @{referencedType.moduleName}_python.@{refedPackage}.@{convertName(referencedType.simpleName)} import @{referencedType.simpleName}\n
+		@code{refedPackage = referencedType.raw.packageName}
+		@code{lastPackage = refedPackage.substring(refedPackage.lastIndexOf('.') + 1)}
+		@code{refedType = referencedType.raw.simpleName}
+		from vertx_python.@{lastPackage}.@{convertName(refedType)} import @{refedType}\n
 		@code{imported.add(referencedType.simpleName)}
 	@end{}
 @end{}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -141,8 +141,6 @@ result.result()
 		@end{}
 	@else{returnType.kind == CLASS_JSON_OBJECT || returnType.kind == CLASS_JSON_ARRAY}
 		util.java_to_python(@includeNamed{templ})
-	@else{returnType.kind.basic || returnType.name.equals('void')}
-		@includeNamed{templ}
 	@else{returnType.kind == CLASS_API}
 		@if{returnType.raw != null}
 			@if{returnType.raw.simpleName.equals("Throwable")}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -104,7 +104,6 @@
 				return "util.java_to_python(" + expr ")";
 			}
 		} else if (kind == CLASS_ENUM) {
-			System.out.println("HEY HEY HEY HEY " +type.name);
 			return expr + ".toString()";
 		} else if (kind.basic) {
 			var typeName = type.name;

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -5,7 +5,7 @@
 	def requiresTypeCheck(methods) {
 		for (method : methods) {
 			for (param : method.params) {
-				if ([CLASS_PRIMITIVE, CLASS_BOXED_PRIMITIVE, CLASS_STRING, CLASS_JSON_ARRAY, CLASS_JSON_OBJECT, CLASS_HANDLER, CLASS_OPTIONS].contains(param.type.kind)) {
+				if ([CLASS_PRIMITIVE, CLASS_BOXED_PRIMITIVE, CLASS_STRING, CLASS_JSON_ARRAY, CLASS_JSON_OBJECT, CLASS_HANDLER, CLASS_DATA_OBJECT].contains(param.type.kind)) {
 					return true;
 				}
 			}
@@ -53,29 +53,28 @@
 	@end{", "})
 @end{}
 
-@comment{"Generate the code that converts a parameter from JavaScript to Java to call a Java API method"}
+@comment{"Generate the code that converts a parameter from Python to Java to call a Java API method"}
 @comment{"============================================================================================="}
 
 @declare{'convParam'}
 	@code{paramName = overloaded ? argName : param.name;}
-	@if{param.type.name.startsWith('io.vertx.core.Handler<')}
-		@code{genericType = helper.getGenericType(param.type.name)}
-		@if{genericType.startsWith('io.vertx.core.AsyncResult<')}
-			Async@{helper.getNonGenericType(helper.getSimpleName(helper.getGenericType(genericType))).replace('<', '').replace('>', '')}Handler(@{paramName})
-		@else{genericType.equals('java.lang.Void')}
+	@if{param.type.kind == CLASS_HANDLER}
+		@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
+			Async@{param.type.args[0].args[0].raw.simpleName}Handler(@{paramName})
+		@else{param.type.args[0].name == "java.lang.Void"}
 			@{paramName}
 		@else{}
-			@{helper.getNonGenericType(helper.getSimpleName(genericType))}Handler(@{paramName})
+			@{param.type.args[0].raw.simpleName}Handler(@{paramName})
 		@end{}
-	@else{param.type.name.equals('io.vertx.core.json.JsonObject')}
+	@else{param.type.kind == CLASS_JSON_OBJECT}
 		util.dict_to_json(@{paramName})
-	@else{param.type.name.equals('io.vertx.core.json.JsonArray')}
+	@else{param.type.kind == CLASS_JSON_ARRAY}
 		util.list_to_json(@{paramName})
-	@else{param.options}
-		@{helper.getSimpleName(param.type.name)}.optionsFromJson(util.dict_to_json(@{paramName})) if @{paramName} is not None else None
+	@else{param.dataObject}
+		@{param.type.simpleName}.optionsFromJson(util.dict_to_json(@{paramName})) if @{paramName} is not None else None
 	@else{param.type.kind == CLASS_OBJECT}
 		util.python_to_java(@{paramName})
-	@else{helper.isBasicType(param.type.name) || param.type.name.equals('java.lang.Void')}
+	@else{param.type.kind.basic || param.type.name == "java.lang.Void"}
 		@{convertName(paramName)}
 	@else{}
 		@{paramName}._jdel()
@@ -90,28 +89,28 @@ result
 result.result()
 @end{}
 
-@comment{"Generate the code that converts a Java return to the corresponding JavaScript value"}
+@comment{"Generate the code that converts a Java return to the corresponding Python value"}
 @comment{"This is also used for converting values returned from Java API via handlers"}
 @comment{"==================================================================================="}
 
 @declare{'convReturn'}
-	@code{genericType=helper.getGenericType(returnType)}
-	@if{returnType.startsWith('java.util.List') || returnType.startsWith('java.util.Set')}
-		@if{genericType.equals('io.vertx.core.json.JsonObject')}
+	@if{returnType.kind == CLASS_LIST || returnType.kind == CLASS_SET}
+		@code{elementType=returnType.args[0]}
+		@if{elementType.kind == CLASS_JSON_OBJECT}
 			util.list_obj_to_python(@includeNamed{templ}, dict)
-		@else{genericType.equals('io.vertx.core.json.JsonArray')}
+		@else{elementType.kind == CLASS_JSON_ARRAY}
 			util.list_obj_to_python(@includeNamed{templ}, list)
-		@else{helper.isVertxGenType(helper.getGenericType(returnType))}
-			util.list_obj_to_python(@includeNamed{templ}, @{helper.getGenericType(returnType)})
+		@else{elementType.kind == CLASS_API}
+			util.list_obj_to_python(@includeNamed{templ}, @{elementType.raw.simpleName})
 		@else{}
 			@includeNamed{templ}
 		@end{}
-	@else{returnType.equals('io.vertx.core.json.JsonObject') || returnType.equals('io.vertx.core.json.JsonArray')}
+	@else{returnType.kind == CLASS_JSON_OBJECT || returnType.kind == CLASS_JSON_ARRAY}
 		util.java_to_python(@includeNamed{templ})
-	@else{helper.isBasicType(returnType) || returnType.equals('java.lang.Void')}
+	@else{returnType.kind.basic || returnType.equals('java.lang.Void')}
 		@includeNamed{templ}
 	@else{method.returnType.kind == CLASS_API}
-		@{helper.getSimpleName(helper.getNonGenericType(returnType))}(@includeNamed{templ})
+		@{returnType.raw.simpleName}(@includeNamed{templ})
 	@else{}
 	@comment{'This will probably happen if the return type is generic'}
 		util.java_to_python(@includeNamed{templ})
@@ -163,7 +162,7 @@ result.result()
 			@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, (list, tuple))
 		@else{param.type.kind == CLASS_HANDLER}
 			@{convertName(param.name)} is not None and callable(@{convertName(param.name)})
-		@else{param.type.kind == CLASS_OPTIONS}
+		@else{param.type.kind == CLASS_DATA_OBJECT}
 			len(@{convertName(param.name)}) > 0
 		@else{}
 			True
@@ -181,7 +180,7 @@ result.result()
 	@foreach{method: methodList}
 		@if{cnt == 0}
 			@foreach{param: method.params}
-				@if{param.type.kind == CLASS_OPTIONS}
+				@if{param.type.kind == CLASS_DATA_OBJECT}
 					@code{optionsParam = param}
 				@end{}
 				@code{requiredParams.add(param.name);}
@@ -191,7 +190,7 @@ result.result()
 			@code{newRequiredParams = []}
 			@foreach{param: method.params}
 				@if{!paramNames.contains(param.name)}@code{paramNames.add(param.name)}@end{}
-				@if{param.type.kind == CLASS_OPTIONS}
+				@if{param.type.kind == CLASS_DATA_OBJECT}
 					@code{optionsParam = param}
 				@end{}
 				@if{requiredParams.contains(param.name)}
@@ -255,7 +254,7 @@ result.result()
 				@if{baseMethod.fluent}
 					@{ind}        @includeNamed{'genMethodCall'; method=baseMethod}\n
 				@else{}
-					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType.name; method=baseMethod}\n
+					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType; method=baseMethod}\n
 				@end{}
 				@{ind}    else:\n
 				@{ind}        raise TypeError("Invalid arguments for @{convertName(methodName)}")\n
@@ -263,7 +262,7 @@ result.result()
 				@if{baseMethod.fluent}
 					@{ind}    @includeNamed{'genMethodCall'; method=baseMethod}\n
 				@else{}
-					@{ind}    return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType.name; method=baseMethod}\n
+					@{ind}    return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType; method=baseMethod}\n
 				@end{}
 			@end{}
 		@else{}
@@ -273,7 +272,7 @@ result.result()
 				@if{method.fluent}
 					@{ind}        @includeNamed{'genMethodCall'}\n
 				@else{}
-					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=method.returnType.name}\n
+					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=method.returnType}\n
 				@end{}
 			@end{}
 			@if{requiresTypeCheck([baseMethod])}
@@ -281,7 +280,7 @@ result.result()
 				@if{baseMethod.fluent}
 					@{ind}        @includeNamed{'genMethodCall'; method=baseMethod}\n
 				@else{}
-					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType.name; method=baseMethod}\n
+					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType; method=baseMethod}\n
 				@end{}
 				@{ind}    else:\n
 				@{ind}        raise TypeError("Invalid arguments for @{convertName(methodName)}")\n
@@ -290,7 +289,7 @@ result.result()
 				@if{baseMethod.fluent}
 					@{ind}        @includeNamed{'genMethodCall'; method=baseMethod}\n
 				@else{}
-					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType.name; method=baseMethod}\n
+					@{ind}        return @includeNamed{'convReturn'; templ='genMethodCall'; returnType=baseMethod.returnType; method=baseMethod}\n
 				@end{}
 			@end{}
 			@if{baseMethod.fluent}
@@ -311,11 +310,10 @@ result.result()
 	@foreach{method: methodList}
 		@foreach{param: method.params}
 			@if{param.type.name.startsWith('io.vertx.core.Handler<') && !handlers.contains(param.type.name)}
-				@code{genericType = helper.getGenericType(param.type.name)}
-				@if{genericType.startsWith('io.vertx.core.AsyncResult<')}
-					@code{className = 'Async' + helper.getNonGenericType(helper.getSimpleName(helper.getGenericType(genericType))).replace('<', '').replace('>', '') + 'Handler'}
+				@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
+					@code{className = 'Async' + param.type.args[0].args[0].raw.simpleName + 'Handler'}
 				@else{}
-					@code{className = helper.getNonGenericType(helper.getSimpleName(genericType)) + 'Handler'}
+					@code{className = param.type.args[0].raw.simpleName + 'Handler'}
 				@end{}
 				class @{className}(object):\n
 				    class Java:\n
@@ -323,17 +321,17 @@ result.result()
 				    def __init__(self, handler):\n
 				        self.handler = handler\n
 				    def handle(self, result):\n
-				@if{genericType.startsWith('io.vertx.core.AsyncResult<')}
+				@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
 					        if result.succeeded():\n
-					@if{helper.getGenericType(genericType).startsWith('java.lang.Void')}
+					@if{param.type.args[0].name.startsWith('java.lang.Void')}
 						            self.handler(None, None)\n
 					@else{}
-						            self.handler(@includeNamed{'convReturn'; templ='arVal'; returnType=helper.getGenericType(genericType)}, None)\n
+						            self.handler(@includeNamed{'convReturn'; templ='arVal'; returnType=param.type.args[0].args[0]}, None)\n
 					@end{}
 					        else:\n
 					            self.handler(None, result.cause())\n
 				@else{}
-					        self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=genericType})\n
+					        self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=param.type.args[0]})\n
 				@end{}
 				\n
 				@code{handlers.add(param.type.name)}
@@ -372,7 +370,7 @@ util.vertx_init()\n
 @comment{"Generate the imports"}
 
 @foreach{referencedType : referencedTypes}
-	@code{refedType = helper.getNonGenericType(referencedType.name)}
+	@code{refedType = referencedType.raw.name}
 	@code{refedPackage = refedType.substring(refedType.lastIndexOf('.', refedType.lastIndexOf('.') - 1) + 1, refedType.lastIndexOf('.'))}
 	from @{referencedType.moduleName}_python.@{refedPackage}.@{convertName(referencedType.simpleName)} import @{referencedType.simpleName}\n
 @end{}
@@ -380,14 +378,14 @@ util.vertx_init()\n
 
 @comment{"The top level vars for the module"}
 
-@foreach{optionType: referencedOptionsTypes}
-	@{helper.getSimpleName(optionType)} = util.jvm.@{optionType}\n
+@foreach{dataObjectType: referencedDataObjectTypes}
+	@{dataObjectType.simpleName} = util.jvm.@{dataObjectType}\n
 @end{}
 \n
 @code{ifaceName = helper.decapitaliseFirstLetter(ifaceSimpleName)}
 
 @comment{"The class"}
-class @{ifaceSimpleName}(@foreach{superType: superTypes}@{helper.getSimpleName(helper.getNonGenericType(superType))}@end{", "}@if{!superTypes.isEmpty()}, object@else{}object@end{}):\n
+class @{ifaceSimpleName}(@foreach{superType: superTypes}@{superType.raw.simpleName}@end{", "}@if{!superTypes.isEmpty()}, object@else{}object@end{}):\n
 
 @comment{"The main comment"}
 @if{ifaceComment != null}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -342,7 +342,7 @@ result.result()
 				@end{}
 				class @{className}(object):\n
 				    class Java:\n
-				        implements = 'io.vertx.core.Handler'\n
+				        implements = ['io.vertx.core.Handler']\n
 				    def __init__(self, handler):\n
 				        self.handler = handler\n
 				    def handle(self, result):\n

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -89,6 +89,13 @@
 			return "util.java_to_python(" + expr + ", hashable=" + boolToStr(hashable) + ")";
 		} else if (kind == CLASS_DATA_OBJECT) {
 			return "util.data_object_to_json(" + expr + ", hashable=" + boolToStr(hashable) + ")";
+		} else if (kind == CLASS_MAP) {
+			var keyType = type.args[0];
+			var valueType = type.args[1];
+			return "{" + convReturn(keyType, "k", hashable) + " : " + 
+                   convReturn(valueType, "v", hashable) + " for k,v in " + expr + ".items()}";
+			
+			return "util.java_map_to_dict(" + expr + ", hashable=" + boolToStr(hashable) + ")";
 		} else if (kind == CLASS_API) {
 			if (type.raw != null) {
 				if (type.raw.simpleName.equals("Throwable")) {
@@ -251,6 +258,7 @@
 @declare{'genMethod'}
 	@code{methodList = methodsByName.get(methodName); overloaded = methodList.size() > 1; method = methodList.get(0);}
 
+
 	@code{requiredParams = []; optionalParams = []; optionsParam = null; paramNames = []; cnt = 0;}
 	@foreach{method: methodList}
 		@if{cnt == 0}
@@ -274,22 +282,21 @@
 					@code{optionalParams.add(param.name)}
 				@end{}
 			@end{}
+			@comment{"Any formerly required params that aren't in newRequired should be optional"}
+			@foreach{param: requiredParams}
+				@if{!newRequiredParams.contains(param) && 
+                    !optionalParams.contains(param)}
+					@code{optionalParams.add(param)}
+				@end{}
+			@end{}
 			@code{requiredParams = newRequiredParams}
 		@end{}
 	@end{}
 
-	@code{childMethods = []}
-	@foreach{method: methodList}
-		@code{base = true; methodParamNames = getParamNames(method)}
-		@foreach{methodParamName : methodParamNames}
-			@if{!requiredParams.contains(methodParamName)}
-				@code{base = false}
-			@end{}
-		@end{}
-		@if{!base}@code{childMethods.add(method)}@end{}
-	@end{}
-
+	@comment{"Try to find 'base' overloaded method. It may not exist, though."}
+	@comment{"If we don't find it, we 'force' it by using the first in the list."}
 	@code{baseMethod = null}
+	@code{forced = false}
 	@foreach{method: methodList}
 		@code{base = true; methodParamNames = getParamNames(method)}
 		@foreach{methodParamName : methodParamNames}
@@ -298,6 +305,26 @@
 			@end{}
 		@end{}
 		@if{base}@code{baseMethod = method}@end{}
+	@end{}
+	@if{baseMethod == null && methodList.size() > 1}
+		@code{forced = true}
+		@code{baseMethod = methodList.get(0)}
+	@end{}
+
+	@code{childMethods = []}
+	@code{zcnt = 0}
+	@foreach{method: methodList}
+		@code{base = true; methodParamNames = getParamNames(method)}
+		@comment{"Add all non-base methods to child list. Handle case where we forced a base."}
+		@if{!forced || zcnt > 0}
+			@foreach{methodParamName : methodParamNames}
+				@if{!requiredParams.contains(methodParamName)}
+					@code{base = false}
+				@end{}
+			@end{}
+		@end{}
+		@code{zcnt++}
+		@if{!base}@code{childMethods.add(method)}@end{}
 	@end{}
 
 	@if{baseMethod != null && static == method.staticMethod}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -389,6 +389,7 @@ result.result()
 @comment{"Import utility functions into all modules"}
 
 from vertx_python import util\n
+from vertx_python.compat import *
 \n
 
 @comment{"Initalize the Vert.x client if necessary"}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -184,17 +184,61 @@
 			}
         } else if (kind == CLASS_LIST) {
 			var element = type.args[0];
-			return "util.python_list_to_java([" + convParam("i", element)  +" for i in " + paramName + "])"
+			var elementName = element.name;
+			if (elementName == 'byte' || elementName == 'java.lang.Byte') {
+				return "util.jvm.io.vertx.lang.python.TypeHelper.toByteList(" +
+					   "util.python_list_to_java([" + convParam("i", element) +
+                       " for i in " + paramName + "] if " + paramName + 
+                       " is not None else None))";
+			} else if (elementName == 'short' || elementName == 'java.lang.Short') {
+				return "util.jvm.io.vertx.lang.python.TypeHelper.toShortList(" + 
+                       "util.python_list_to_java([" + convParam("i", element) +
+					    " for i in " + paramName + "] if " + paramName + 
+                        " is not None else None))";
+			} else {
+				return "util.python_list_to_java([" + convParam("i", element)  +
+					   " for i in " + paramName + "] if " + paramName + 
+                       " is not None else None)";
+			}
         } else if (kind == CLASS_SET) {
 			var element = type.args[0];
-			return "util.python_set_to_java(set([" + convParam("i", element)  +" for i in " + paramName + "]))"
+			var elementName = element.name;
+			if (elementName == 'byte' || elementName == 'java.lang.Byte') {
+				return "util.jvm.io.vertx.lang.python.TypeHelper.toByteSet(" +
+					   "util.python_set_to_java([" + convParam("i", element) +
+                       " for i in " + paramName + "] if " + paramName + 
+                       " is not None else None))";
+			} else if (elementName == 'short' || elementName == 'java.lang.Short') {
+				return "util.jvm.io.vertx.lang.python.TypeHelper.toShortSet(" + 
+                       "util.python_set_to_java([" + convParam("i", element) +
+					    " for i in " + paramName + "] if " + paramName + 
+                        " is not None else None))";
+			} else {
+				return "util.python_set_to_java([" + convParam("i", element)  +
+					   " for i in " + paramName + "] if " + paramName + 
+                       " is not None else None)";
+			}
 		} else if (kind == CLASS_OBJECT) {
 			return "util.python_to_java(" + paramName + ")";
 		} else if (kind == CLASS_MAP) {
 		    var keyType = type.args[0];
             var valueType = type.args[1];
-			return "util.python_map_to_java({" + convParam("k", keyType) + ":" + convParam("v", valueType) +
-                    " for k,v in  iteritems(" + paramName + ")})";
+			var elementName = valueType.name;
+			if (elementName == 'byte' || elementName == 'java.lang.Byte') {
+				return "util.jvm.io.vertx.lang.python.TypeHelper.toByteMap(" + 
+                       "util.python_map_to_java({" + convParam("k", keyType) + 
+					   ":" + convParam("v", valueType) + 
+                       " for k,v in iteritems(" + paramName + ")}))";
+			} else if (elementName == 'short' || elementName == 'java.lang.Short') {
+				return "util.jvm.io.vertx.lang.python.TypeHelper.toShortMap(" + 
+                       "util.python_map_to_java({" + convParam("k", keyType) + 
+					   ":" + convParam("v", valueType) + 
+                       " for k,v in iteritems(" + paramName + ")}))";
+			} else {
+				return "util.python_map_to_java({" + convParam("k", keyType) + 
+					   ":" + convParam("v", valueType) + 
+                       " for k,v in iteritems(" + paramName + ")})";
+			}
 		} else if (kind == CLASS_ENUM) {
 			return "util.jvm." + type.name + ".valueOf(" + paramName + ")";
 		} else if (kind.basic || typeName.equals("java.lang.Void")) {

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -395,8 +395,9 @@ result.result()
 
 @comment{"Import utility functions into all modules"}
 
+from __future__ import unicode_literals, print_function, absolute_import\n
 from vertx_python import util\n
-from vertx_python.compat import *
+from vertx_python.compat import *\n
 \n
 
 @comment{"Initalize the Vert.x client if necessary"}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -190,7 +190,7 @@ result.result()
 				param.type.name == 'double' || param.type.name == 'java.lang.Double'}
 				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, float)
 			@else{param.type.name == 'byte' || param.type.name == 'java.lang.Byte'}
-				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, bytes)
+				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, int)
 			@else{param.type.name == 'boolean' || param.type.name == 'java.lang.Boolean'}
 				@{convertName(param.name)} is not None and isinstance(@{convertName(param.name)}, bool)
 			@else{param.type.name == 'char' || param.type.name == 'java.lang.Character'}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -79,7 +79,7 @@
 	@else{param.type.kind == CLASS_JSON_ARRAY}
 		util.list_to_json(@{convertName(paramName)})
 	@else{param.dataObject}
-		@{param.type.simpleName}.optionsFromJson(util.dict_to_json(@{convertName(paramName)})) if @{convertName(paramName)} is not None else None
+		@{param.type.simpleName}(util.dict_to_json(@{convertName(paramName)})) if @{convertName(paramName)} is not None else None
 	@else{param.type.kind == CLASS_OBJECT}
 		util.python_to_java(@{convertName(paramName)})
 	@else{param.type.kind.basic || param.type.name.equals("java.lang.Void")}
@@ -179,7 +179,8 @@ result.result()
 		@else{param.type.kind == CLASS_HANDLER}
 			@{convertName(param.name)} is not None and callable(@{convertName(param.name)})
 		@else{param.type.kind == CLASS_DATA_OBJECT}
-			len(@{convertName(param.name)}) > 0
+			True
+			@comment{"len(@{convertName(param.name)}) > 0"}
 		@else{}
 			@comment{"This could possibly be smarter and do an isinstance check sometimes (not always, though)"}
 			@{convertName(param.name)} is not None
@@ -346,22 +347,28 @@ result.result()
 				    def __init__(self, handler):\n
 				        self.handler = handler\n
 				    def handle(self, result):\n
-				@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
-					        if result.succeeded():\n
-					@if{param.type.args[0].args[0].name.startsWith('java.lang.Void')}
-						            self.handler(None, None)\n
+				        try:\n
+					@if{param.type.args[0].kind == CLASS_ASYNC_RESULT}
+				            if result.succeeded():\n
+						@if{param.type.args[0].args[0].name.startsWith('java.lang.Void')}
+				                self.handler(None, None)\n
+						@else{}
+				                self.handler(@includeNamed{'convReturn'; templ='arVal'; returnType=param.type.args[0].args[0]}, None)\n
+						@end{}
+				            else:\n
+				                self.handler(None, result.cause())\n
 					@else{}
-						            self.handler(@includeNamed{'convReturn'; templ='arVal'; returnType=param.type.args[0].args[0]}, None)\n
+						@if{param.type.args[0].name.startsWith('java.lang.Void')}
+				            self.handler(None)\n
+						@else{}
+				            self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=param.type.args[0]})\n
+						@end{}
 					@end{}
-					        else:\n
-					            self.handler(None, result.cause())\n
-				@else{}
-					@if{param.type.args[0].name.startsWith('java.lang.Void')}
-					                self.handler(None)\n
-					@else{}
-					        self.handler(@includeNamed{'convReturn'; templ='resultVal'; returnType=param.type.args[0]})\n
-					@end{}
-				@end{}
+				        except Exception:\n
+				            import traceback\n
+				            traceback.print_exc()\n
+				            raise\n
+				
 				\n
 				@code{handlers.add(param.type.name)}
 			@end{}

--- a/src/main/resources/vertx_python/template/python.templ
+++ b/src/main/resources/vertx_python/template/python.templ
@@ -458,7 +458,7 @@
 						                self.handler(@{convReturn(param.type.args[0].args[0], "result.result()", false)}, None)\n
 								@end{}
 						            else:\n
-						                self.handler(None, result.cause())\n
+						                self.handler(None, util.VertxException(result.cause().getMessage()))\n
 							@else{}
 								@if{param.type.args[0].name.startsWith('java.lang.Void')}
 						            self.handler(None)\n

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -46,7 +46,6 @@ def parse_array(old_parse_array, *args, **kwargs):
     values, end = old_parse_array(*args, **kwargs)
     return frozenset(values), end
 
-
 class FrozenDecoder(json.JSONDecoder):
     ''' Decoder that will use frozensets insteadof lists for JSON arrays. '''
     def __init__(self, *args, **kwargs):
@@ -54,8 +53,6 @@ class FrozenDecoder(json.JSONDecoder):
         old_parse_array = self.parse_array
         self.parse_array = partial(parse_array, old_parse_array)
         self.scan_once = json.scanner.py_make_scanner(self)
-
-
 
 
 class frozendict(dict, collections.Mapping):
@@ -73,7 +70,7 @@ class frozendict(dict, collections.Mapping):
         return frozendict(self, **add_or_replace)
 
     def __repr__(self):
-        return '<frozendict %s>' % repr(self.__dict)
+        return '<frozendict %s>' % repr(super(frozendict, self).__repr__())
 
     def __hash__(self):
         if self.__hash is None:

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -7,6 +7,15 @@ jvertx = None
 
 @contextmanager
 def handle_java_error():
+    """ Protect calls to the Java Gateway.
+    
+    This decorate ensures the properly cleanup is done if a call
+    to the Java Gateway throws an exception. Failure to do so can
+    leave the program in a hung state, because the Py4J callback
+    server thread will keep running in the background, preventing
+    the interpreter from exiting.
+    
+    """
     try:
         yield
     except Exception:

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, print_function, absolute_import
 import json
 import collections
 import operator
-from functools import partial
+from functools import partial, wraps
 from contextlib import contextmanager
 
 from .compat import unicode, long, basestring
@@ -161,3 +161,14 @@ def java_to_python(obj, hashable=False):
         return json_to_python(obj, hashable=hashable)
     else:
         return obj
+
+
+def cached(func):
+    dct = dict(cached_ret=None)
+    @wraps(func)
+    def inner(*args, **kwargs):
+        if dct['cached_ret'] is None:
+            dct['cached_ret'] = func(*args, **kwargs)
+        return dct['cached_ret']
+    return inner
+

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -19,7 +19,7 @@ def vertx_init():
             raise RuntimeError("Failed to connect to Vert.x")
         try:
             from py4j.java_gateway import JavaGateway, GatewayClient
-            java_gateway = JavaGateway(GatewayClient(port=int(port)))
+            java_gateway = JavaGateway(GatewayClient(port=int(port)), start_callback_server=True)
             jvm = java_gateway.jvm
             jvertx = java_gateway.entry_point.getVertx()
         except ImportError:

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -16,6 +16,9 @@ java_gateway = None
 jvm = None
 jvertx = None
 
+class VertxException(Exception):
+    pass
+
 class AdaptingMap(JavaMap):
     def __init__(self, map, java_converter, python_converter):
         JavaMap.__init__(self, map._target_id, map._gateway_client)

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -21,7 +21,7 @@ def vertx_init():
             from py4j.java_gateway import JavaGateway, GatewayClient
             java_gateway = JavaGateway(GatewayClient(port=int(port)), 
                                        start_callback_server=True,
-                                       python_proxy_port=24332)
+                                       python_proxy_port=int(sys.argv[2]))
             jvm = java_gateway.jvm
             jvertx = java_gateway.entry_point.getVertx()
         except ImportError:

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -1,10 +1,43 @@
 import json
-from py4j.java_gateway import is_instance_of
-from py4j.protocol import Py4JNetworkError
+import socket
+from threading import Thread
+from py4j.java_gateway import (is_instance_of, CallbackServer, logger, 
+                               Py4JNetworkError, JavaGateway)
 
 java_gateway = None
 jvm = None
 jvertx = None
+
+class DaemonCallbackServer(CallbackServer):
+    ''' Start listening thread as a daemon to prevent hangs. '''
+    def start(self):
+        """Starts the CallbackServer. This method should be called by the
+        client instead of run()."""
+        self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR,
+                1)
+        try:
+            self.server_socket.bind((self.address, self.port))
+        except Exception:
+            msg = 'An error occurred while trying to start the callback server'
+            logger.exception(msg)
+            raise Py4JNetworkError(msg)
+
+        # Maybe thread needs to be cleanup up?
+        self.thread = Thread(target=self.run)
+        self.thread.daemon = True
+        self.thread.start()
+
+class DaemonJavaGateway(JavaGateway):
+    def _start_callback_server(self, python_proxy_port):
+        self._callback_server = DaemonCallbackServer(self.gateway_property.pool,
+                self._gateway_client, python_proxy_port)
+        try:
+            self._callback_server.start()
+        except Py4JNetworkError:
+            # Clean up ourselves before raising the exception.
+            self.shutdown()
+            raise
 
 def vertx_init():
     """Initializes the Vert.x connection."""
@@ -19,12 +52,12 @@ def vertx_init():
         except IndexError:
             raise RuntimeError("Failed to connect to Vert.x")
         try:
-            from py4j.java_gateway import JavaGateway, GatewayClient
+            from py4j.java_gateway import GatewayClient
             proxy_port = int(sys.argv[2])
-            java_gateway = JavaGateway(GatewayClient(port=int(port)), 
-                                       start_callback_server=True,
-                                       eager_load=True,
-                                       python_proxy_port=proxy_port)
+            java_gateway = DaemonJavaGateway(GatewayClient(port=int(port)), 
+                                             start_callback_server=True,
+                                             eager_load=True,
+                                             python_proxy_port=proxy_port)
             jvm = java_gateway.jvm
             jvertx = java_gateway.entry_point.getVertx()
         except ImportError:

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -30,6 +30,9 @@ def vertx_init():
         except ImportError:
             raise RuntimeError("Failed to connect to Vert.x. Py4J must be on your PYTHONPATH")
 
+def convert_char(ch):
+    return chr(ch) if isinstance(ch, int) else ch
+
 def json_to_python(obj):
     """Converts a Java JSON object to Python dict or list"""
     return json.loads(obj.encode()) if obj is not None else None

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -6,11 +6,10 @@ import operator
 from functools import partial, wraps
 from contextlib import contextmanager
 
-from .compat import unicode, long, basestring
-
 from py4j.java_gateway import is_instance_of
-from py4j.compat import iteritems
 from py4j.java_collections import MapConverter, ListConverter, SetConverter, JavaMap
+
+from .compat import iteritems, reduce
 
 java_gateway = None
 jvm = None
@@ -78,7 +77,7 @@ class frozendict(dict, collections.Mapping):
 
     def __hash__(self):
         if self.__hash is None:
-            self.__hash = reduce(operator.xor, map(hash, self.iteritems()), 0)
+            self.__hash = reduce(operator.xor, map(hash, iteritems(self)), 0)
         return self.__hash
 
 

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -77,35 +77,9 @@ def convert_double_to_java(x):
 def convert_float_to_java(x):
     return jvm.java.lang.Float(x)
 
-def convert_short_list_to_java(lst):
-    return list_to_json([convert_short_to_java(i) for i in lst])
-
-def convert_long_list_to_java(lst):
-    return list_to_json([convert_long_to_java(i) for i in lst])
-
-def convert_byte_list_to_java(lst):
-    return list_to_json([convert_byte_to_java(i) for i in lst])
-
-def convert_double_list_to_java(lst):
-    return list_to_json([convert_double_to_java(i) for i in lst])
-
-def convert_float_list_to_java(lst):
-    return list_to_json([convert_float_to_java(i) for i in lst])
-
 def json_to_python(obj):
     """Converts a Java JSON object to Python dict or list"""
     return json.loads(obj.encode()) if obj is not None else None
-
-def list_obj_to_python(obj, type):
-    """Converts a Java iterable of objects to a Python list"""
-    if obj is None:
-        return None
-    result = []
-    iterator = obj.iterator()
-    while iterator.hasNext():
-        val = iterator.next()
-        result.append(type(json.loads(val.encode())) if val is not None else None)
-    return result
 
 def list_to_json(obj):
     """Converts a Python list to Java JsonArray"""
@@ -124,7 +98,6 @@ def python_to_java(obj):
     elif isinstance(obj, list):
         return list_to_json(obj)
     return obj
-
 
 def data_object_to_json(obj):
     return java_to_python(obj.toJson())

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -125,6 +125,10 @@ def python_to_java(obj):
         return list_to_json(obj)
     return obj
 
+
+def data_object_to_json(obj):
+    return java_to_python(obj.toJson())
+
 def java_to_python(obj):
     """Converts an arbitrary Java object to Python"""
     if obj is None:

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -11,7 +11,7 @@ def vertx_init():
     global jvm
     global jvertx
 
-    if not hasattr(__builtins__, 'jvm'):
+    if not hasattr(__builtins__, 'jvm') and not all([jvm, jvertx, java_gateway]):
         import sys
         try:
             port = sys.argv[1]
@@ -19,7 +19,9 @@ def vertx_init():
             raise RuntimeError("Failed to connect to Vert.x")
         try:
             from py4j.java_gateway import JavaGateway, GatewayClient
-            java_gateway = JavaGateway(GatewayClient(port=int(port)), start_callback_server=True)
+            java_gateway = JavaGateway(GatewayClient(port=int(port)), 
+                                       start_callback_server=True,
+                                       python_proxy_port=24332)
             jvm = java_gateway.jvm
             jvertx = java_gateway.entry_point.getVertx()
         except ImportError:

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from py4j.java_gateway import is_instance_of
 from py4j.java_collections import MapConverter, ListConverter, SetConverter, JavaMap
 
-from .compat import iteritems, reduce
+from .compat import reduce, iteritems
 
 java_gateway = None
 jvm = None

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -64,7 +64,7 @@ def java_to_python(obj):
     """Converts an arbitrary Java object to Python"""
     if obj is None:
         return None
-    elif is_instance_of(obj, jvm.io.vertx.core.json.JsonObject) or is_instance_of(obj, jvm.io.vertx.core.json.JsonArray):
+    elif is_instance_of(java_gateway, obj, jvm.io.vertx.core.json.JsonObject) or is_instance_of(java_gateway, obj, jvm.io.vertx.core.json.JsonArray):
         return json_to_python(obj)
     else:
         return obj

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -198,13 +198,13 @@ def python_to_java(obj):
     return obj
 
 def python_map_to_java(obj):
-    return MapConverter().convert(obj, java_gateway._gateway_client)
+    return MapConverter().convert(obj, java_gateway._gateway_client) if obj else obj
 
 def python_set_to_java(obj):
-    return SetConverter().convert(obj, java_gateway._gateway_client)
+    return SetConverter().convert(obj, java_gateway._gateway_client) if obj else obj
 
 def python_list_to_java(obj):
-    return ListConverter().convert(obj, java_gateway._gateway_client)
+    return ListConverter().convert(obj, java_gateway._gateway_client) if obj else obj
 
 def data_object_to_json(obj, hashable=False):
     if obj is None:

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -1,5 +1,9 @@
+from __future__ import unicode_literals, print_function, absolute_import
+
 import json
 from contextlib import contextmanager
+
+from py4j.java_gateway import is_instance_of
 
 java_gateway = None
 jvm = None
@@ -19,8 +23,17 @@ def handle_java_error():
     try:
         yield
     except Exception:
-        java_gateway.shutdown()
+        vertx_shutdown()
         raise
+
+def vertx_shutdown():
+    global java_gateway
+    global jvm
+    global jvertx
+    java_gateway.close()
+    jvm = None
+    jvertx = None
+    java_gateway = None
 
 def vertx_init():
     """Initializes the Vert.x connection."""

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -23,6 +23,7 @@ def handle_java_error():
     try:
         yield
     except Exception:
+        print("EXCEPT CALLING IT")
         vertx_shutdown()
         raise
 

--- a/src/main/resources/vertx_python/util.py
+++ b/src/main/resources/vertx_python/util.py
@@ -1,5 +1,6 @@
 import json
 from py4j.java_gateway import is_instance_of
+from py4j.protocol import Py4JNetworkError
 
 java_gateway = None
 jvm = None
@@ -19,9 +20,11 @@ def vertx_init():
             raise RuntimeError("Failed to connect to Vert.x")
         try:
             from py4j.java_gateway import JavaGateway, GatewayClient
+            proxy_port = int(sys.argv[2])
             java_gateway = JavaGateway(GatewayClient(port=int(port)), 
                                        start_callback_server=True,
-                                       python_proxy_port=int(sys.argv[2]))
+                                       eager_load=True,
+                                       python_proxy_port=proxy_port)
             jvm = java_gateway.jvm
             jvertx = java_gateway.entry_point.getVertx()
         except ImportError:

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -2,12 +2,12 @@ package io.vertx.test.lang.python;
 
 import org.junit.Test;
 
-/**
+/*
  *
  * This test tests all the different types of methods, return values and parameters that can be used in generated
  * APIs.
  *
- * @author <a href="http://tfox.org">Dan O'Reilly</a>
+ * @author Dan O'Reilly
  */
 public class APITest extends PythonTestBase {
 
@@ -18,79 +18,85 @@ public class APITest extends PythonTestBase {
 
   // Test params
 
-  @Test
-  public void testMethodWithBasicParams() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithBasicBoxedParams() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerBasicTypes() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithUserTypes() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testObjectParam() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testDataObjectParam() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testNullDataObjectParam() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerDataObject() throws Exception {
-    runTest();
-  }
-
- 
-  @Test
-  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
-    runTest();
-  }
-   
-  @Test
-  public void testMethodWithHandlerListAndSet() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
-    runTest();
-  }
-
- /*  @Test
+/*
+ *  @Test
+ *  public void testMethodWithBasicParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithBasicBoxedParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerBasicTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithUserTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testObjectParam() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testDataObjectParam() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testNullDataObjectParam() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerDataObject() throws Exception {
+ *    runTest();
+ *  }
+ * 
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
+ *    runTest();
+ *  }
+ *   
+ *  @Test
+ *  public void testMethodWithHandlerListAndSet() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
  *  public void testMethodWithHandlerListVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ */
+/*
+ *  @Test
+ *  public void testMethodWithHandlerListAbstractVertxGen() throws Exception {
  *    runTest();
  *  }
  *
@@ -98,147 +104,8 @@ public class APITest extends PythonTestBase {
  *  public void testMethodWithHandlerUserTypes() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultUserTypes() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithConcreteHandlerUserTypeSubtype() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithAbstractHandlerUserTypeSubtype() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerVoid() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultVoid() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultVoidFails() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerThrowable() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerGenericUserType() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultGenericUserType() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListAbstractVertxGen() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetVertxGen() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetAbstractVertxGen() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListJsonObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListNullJsonObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetJsonObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetNullJsonObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetComplexJsonObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListJsonArray() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListNullJsonArray() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListComplexJsonArray() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetJsonArray() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetNullJsonArray() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetComplexJsonArray() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerNullListDataObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListDataObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerSetDataObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerNullSetDataObject() throws Exception {
- *    runTest();
- *  }
- *
+ */
+/*
  *  @Test
  *  public void testMethodWithHandlerAsyncResultListVertxGen() throws Exception {
  *    runTest();
@@ -248,361 +115,498 @@ public class APITest extends PythonTestBase {
  *  public void testMethodWithHandlerAsyncResultListAbstractVertxGen() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+
+  @Test
+  public void testMethodWithHandlerSetVertxGen() throws Exception {
+    runTest();
+  }
+
+  /*
+   *@Test
+   *public void testMethodWithHandlerAsyncResultUserTypes() throws Exception {
+   *  runTest();
+   *}
+   */
+ /*  @Test
+ *  public void testMethodWithConcreteHandlerUserTypeSubtype() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithAbstractHandlerUserTypeSubtype() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerVoid() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerAsyncResultVoid() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerAsyncResultVoidFails() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerThrowable() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerGenericUserType() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerAsyncResultGenericUserType() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerSetAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerListJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerListNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerSetJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerSetNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerSetComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerListJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerListNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerListComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerSetJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerSetNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerSetComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerNullListDataObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerListDataObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerSetDataObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
+ *  public void testMethodWithHandlerNullSetDataObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetVertxGen() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultListComplexJsonObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultListNullJsonObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetJsonObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetNullJsonObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetComplexJsonObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultListJsonArray() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultListNullJsonArray() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultListComplexJsonArray() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetJsonArray() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetNullJsonArray() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetComplexJsonArray() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultNullListDataObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultListDataObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultSetDataObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithHandlerAsyncResultNullSetDataObject() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithGenericParam() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithGenericHandler() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithGenericHandlerAsyncResult() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testJsonParams() throws Exception {
  *    runTest();
  *  }
- *
- * // FIXME - temporarily commented out until we have proper support for nullable / not nullable params using
+ */
+ /* // FIXME - temporarily commented out until we have proper support for nullable / not nullable params using
  * // codegen
  * //  @Test
  * //  public void testNullJsonParams() throws Exception {
  * //    runTest();
  * //  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testJsonHandlerParams() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testNullJsonHandlerParams() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testComplexJsonHandlerParams() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testJsonHandlerAsyncResultParams() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testNullJsonHandlerAsyncResultParams() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testComplexJsonHandlerAsyncResultParams() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testEnumParam() throws Exception {
  *    runTest();
  *  }
- *
- *
- *  @Test
+ */
+ /*/
+ /*  @Test
  *  public void testMethodWithListParams() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithSetParams() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithMapParams() throws Exception {
  *    runTest();
  *  }
- *
- *  // Test returns
- *
- *  @Test
+ */
+ /*  // Test returns
+ */
+ /*  @Test
  *  public void testBasicReturns() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testVertxGenReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testVertxGenNullReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testAbstractVertxGenReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMapComplexJsonArrayReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testOverloadedMethods() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testSuperInterfaces() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithGenericReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testFluentMethod() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testStaticFactoryMethod() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMethodWithCachedReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testJsonReturns() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testNullJsonReturns() throws Exception {
  *    runTest();
  *  }
- *
- *
- *
- *  @Test
+ */
+ /*/
+ /*/
+ /*  @Test
  *  public void testEnumReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMapReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMapStringReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMapJsonObjectReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMapComplexJsonObjectReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMapJsonArrayReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMapLongReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testMapNullReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testListStringReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testListLongReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testListJsonObjectReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testListComplexJsonObjectReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testListJsonArrayReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testListComplexJsonArrayReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testListVertxGenReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testSetStringReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testSetLongReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testSetJsonObjectReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testSetComplexJsonObjectReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testSetJsonArrayReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testSetComplexJsonArrayReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testSetVertxGenReturn() throws Exception {
  *    runTest();
  *  }
- *
- *
- *  @Test
+ */
+ /*/
+ /*  @Test
  *  public void testThrowableReturn() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+ /*  @Test
  *  public void testCustomModule() throws Exception {
  *    runTest();
  *  }

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -16,521 +16,528 @@ public class APITest extends PythonTestBase {
     return "api_test.py";
   }
 
+  @Test
+  public void testEverything() throws Exception {
+    runTest();
+  }
+
   // Test params
 
-  @Test
-  public void testMethodWithBasicParams() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithBasicBoxedParams() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerBasicTypes() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithUserTypes() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testObjectParam() throws Exception {
-    runTest();
-  }
-   @Test
-   public void testDataObjectParam() throws Exception {
-     runTest();
-   }
- 
-   @Test
-  public void testMethodWithHandlerDataObject() throws Exception {
-    runTest();
-  }
- 
-  @Test
-  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
-    runTest();
-  }
-   
-  @Test
-  public void testMethodWithHandlerListAndSet() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerListVertxGen() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMethodWithHandlerListAbstractVertxGen() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerUserTypes() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMethodWithHandlerAsyncResultListVertxGen() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultListAbstractVertxGen() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerSetVertxGen() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerSetAbstractVertxGen() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultSetVertxGen() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
-    runTest();
-  }
- 
-  @Test
-  public void testMethodWithHandlerListJsonObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerListNullJsonObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultListNullJsonObject() throws Exception {
-    runTest();
-  }
-
-
-  @Test
-  public void testMethodWithHandlerAsyncResultListComplexJsonObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerSetJsonObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerSetNullJsonObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultSetJsonObject() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMethodWithHandlerAsyncResultSetNullJsonObject() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMethodWithHandlerAsyncResultSetComplexJsonObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerListJsonArray() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMethodWithHandlerListNullJsonArray() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMethodWithHandlerListComplexJsonArray() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerSetJsonArray() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerSetNullJsonArray() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerSetComplexJsonArray() throws Exception {
-    runTest();
-  }
-
-   @Test
-  public void testMethodWithHandlerAsyncResultListJsonArray() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultListNullJsonArray() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultListComplexJsonArray() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultSetJsonArray() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultSetNullJsonArray() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultSetComplexJsonArray() throws Exception {
-    runTest();
-  }
-
-   @Test
-  public void testMethodWithHandlerListNullDataObject() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerListDataObject() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerSetDataObject() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerSetNullDataObject() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultListNullDataObject() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultListDataObject() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultSetDataObject() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultSetNullDataObject() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultUserTypes() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithConcreteHandlerUserTypeSubtype() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithAbstractHandlerUserTypeSubtype() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithConcreteHandlerUserTypeSubtypeExtension() throws Exception {
-    runTest();
-  }
-
-   @Test
-  public void testMethodWithHandlerVoid() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultVoid() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerAsyncResultVoidFails() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerThrowable() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithHandlerGenericUserType() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithHandlerAsyncResultGenericUserType() throws Exception {
-    runTest();
-  }
-
-   @Test
-  public void testMethodWithGenericParam() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithGenericHandler() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMethodWithGenericHandlerAsyncResult() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testJsonParams() throws Exception {
-    runTest();
-  }
-   @Test
-   public void testNullJsonParams() throws Exception {
-     runTest();
-   }
-   @Test
-  public void testJsonHandlerParams() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testNullJsonHandlerParams() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testComplexJsonHandlerParams() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testJsonHandlerAsyncResultParams() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testNullJsonHandlerAsyncResultParams() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testComplexJsonHandlerAsyncResultParams() throws Exception {
-    runTest();
-  }
-   // Test returns
-   @Test
-  public void testBasicReturns() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testVertxGenReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testVertxGenNullReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testAbstractVertxGenReturn() throws Exception {
-    runTest();
-  }
-   @Test
-   public void testMapComplexJsonArrayReturn() throws Exception {
-     runTest();
-   }
-  @Test
-  public void testOverloadedMethods() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testSuperInterfaces() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithGenericReturn() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testFluentMethod() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testStaticFactoryMethod() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testMethodWithCachedReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testJsonReturns() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testNullJsonReturns() throws Exception {
-    runTest();
-  }
- 
-  @Test
-  public void testMapReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMapStringReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapJsonObjectReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapComplexJsonObjectReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testMapJsonArrayReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapLongReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapIntegerReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapShortReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapByteReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapCharacterReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapBooleanReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapFloatReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapDoubleReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testMapNullReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testListStringReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testListLongReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testListJsonObjectReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testListComplexJsonObjectReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testListJsonArrayReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testListComplexJsonArrayReturn() throws Exception {
-    runTest();
-  }
-  @Test
-  public void testListVertxGenReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testSetStringReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testSetLongReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testSetJsonObjectReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testSetComplexJsonObjectReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testSetJsonArrayReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testSetComplexJsonArrayReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testSetVertxGenReturn() throws Exception {
-    runTest();
-  }
-   @Test
-  public void testThrowableReturn() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testCustomModule() throws Exception {
-    runTest();
-  }
+/*
+ *  @Test
+ *  public void testMethodWithBasicParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithBasicBoxedParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerBasicTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithUserTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testObjectParam() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *   public void testDataObjectParam() throws Exception {
+ *     runTest();
+ *   }
+ * 
+ *   @Test
+ *  public void testMethodWithHandlerDataObject() throws Exception {
+ *    runTest();
+ *  }
+ * 
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
+ *    runTest();
+ *  }
+ *   
+ *  @Test
+ *  public void testMethodWithHandlerListAndSet() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMethodWithHandlerListAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerUserTypes() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultListAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ * 
+ *  @Test
+ *  public void testMethodWithHandlerListJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMethodWithHandlerListNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMethodWithHandlerListComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerSetJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerSetNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerSetComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultListJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultListNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultListComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultSetJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultSetNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultSetComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *   @Test
+ *  public void testMethodWithHandlerListNullDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerListDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerSetDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerSetNullDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultListNullDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultListDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultSetDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultSetNullDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultUserTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithConcreteHandlerUserTypeSubtype() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithAbstractHandlerUserTypeSubtype() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithConcreteHandlerUserTypeSubtypeExtension() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *   @Test
+ *  public void testMethodWithHandlerVoid() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultVoid() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerAsyncResultVoidFails() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerThrowable() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithHandlerGenericUserType() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultGenericUserType() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *   @Test
+ *  public void testMethodWithGenericParam() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithGenericHandler() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMethodWithGenericHandlerAsyncResult() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testJsonParams() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *   public void testNullJsonParams() throws Exception {
+ *     runTest();
+ *   }
+ *   @Test
+ *  public void testJsonHandlerParams() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testNullJsonHandlerParams() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testComplexJsonHandlerParams() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testJsonHandlerAsyncResultParams() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testNullJsonHandlerAsyncResultParams() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testComplexJsonHandlerAsyncResultParams() throws Exception {
+ *    runTest();
+ *  }
+ *   // Test returns
+ *   @Test
+ *  public void testBasicReturns() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testVertxGenReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testVertxGenNullReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testAbstractVertxGenReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *   public void testMapComplexJsonArrayReturn() throws Exception {
+ *     runTest();
+ *   }
+ *  @Test
+ *  public void testOverloadedMethods() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSuperInterfaces() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithGenericReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testFluentMethod() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testStaticFactoryMethod() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithCachedReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testJsonReturns() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testNullJsonReturns() throws Exception {
+ *    runTest();
+ *  }
+ * 
+ *  @Test
+ *  public void testMapReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMapStringReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapComplexJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testMapJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapLongReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapIntegerReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapShortReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapByteReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapCharacterReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapBooleanReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapFloatReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapDoubleReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testMapNullReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testListStringReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testListLongReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testListJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testListComplexJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testListJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testListComplexJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *  @Test
+ *  public void testListVertxGenReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testSetStringReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testSetLongReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testSetJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testSetComplexJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testSetJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testSetComplexJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testSetVertxGenReturn() throws Exception {
+ *    runTest();
+ *  }
+ *   @Test
+ *  public void testThrowableReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testCustomModule() throws Exception {
+ *    runTest();
+ *  }
+ */
    
   /*
    *@Test

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -67,19 +67,20 @@ public class APITest extends PythonTestBase {
   public void testMethodWithHandlerDataObject() throws Exception {
     runTest();
   }
+
+ 
+   @Test
+   public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
+     runTest();
+   }
 /*
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
- *    runTest();
- *  }
- *
  *  @Test
  *  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
  *    runTest();
  *  }
- *
- *  @Test
+ */
+   
+ /*  @Test
  *  public void testMethodWithHandlerListAndSet() throws Exception {
  *    runTest();
  *  }

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -58,11 +58,6 @@ public class APITest extends PythonTestBase {
    }
  
    @Test
-   public void testNullDataObjectParam() throws Exception {
-     runTest();
-   }
- 
-   @Test
   public void testMethodWithHandlerDataObject() throws Exception {
     runTest();
   }
@@ -393,12 +388,10 @@ public class APITest extends PythonTestBase {
   *   runTest();
   * }
   */
-  /*
-   * @Test
-   *public void testMapComplexJsonArrayReturn() throws Exception {
-   *  runTest();
-   *}
-   */
+   @Test
+  public void testMapComplexJsonArrayReturn() throws Exception {
+    runTest();
+  }
  /*  @Test
  *  public void testOverloadedMethods() throws Exception {
  *    runTest();
@@ -562,4 +555,11 @@ public class APITest extends PythonTestBase {
  *    runTest();
  *  }
  */
+   // This one is disabled because we can't pass a null data object
+  // To the Python API.
+   //@Test
+   //public void testNullDataObjectParam() throws Exception {
+   //  runTest();
+  // }
+ 
 }

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -52,18 +52,17 @@ public class APITest extends PythonTestBase {
   public void testObjectParam() throws Exception {
     runTest();
   }
-
-  @Test
-  public void testDataObjectParam() throws Exception {
-    runTest();
-  }
-
-  @Test
-  public void testNullDataObjectParam() throws Exception {
-    runTest();
-  }
-
-  @Test
+   @Test
+   public void testDataObjectParam() throws Exception {
+     runTest();
+   }
+ 
+   @Test
+   public void testNullDataObjectParam() throws Exception {
+     runTest();
+   }
+ 
+   @Test
   public void testMethodWithHandlerDataObject() throws Exception {
     runTest();
   }
@@ -105,8 +104,7 @@ public class APITest extends PythonTestBase {
   public void testMethodWithHandlerAsyncResultListVertxGen() throws Exception {
     runTest();
   }
-
-  @Test
+   @Test
   public void testMethodWithHandlerAsyncResultListAbstractVertxGen() throws Exception {
     runTest();
   }
@@ -125,34 +123,33 @@ public class APITest extends PythonTestBase {
   public void testMethodWithHandlerAsyncResultSetVertxGen() throws Exception {
     runTest();
   }
-  @Test
-  public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
-    runTest();
-  }
+   @Test
+   public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
+     runTest();
+   }
+ 
 
   @Test
   public void testMethodWithHandlerListJsonObject() throws Exception {
     runTest();
   }
 
+  @Test
+  public void testMethodWithHandlerListNullJsonObject() throws Exception {
+    runTest();
+  }
+
 /*
- *  @Test
- *  public void testMethodWithHandlerListNullJsonObject() throws Exception {
- *    runTest();
- *  }
- *
  *  @Test
  *  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
  *    runTest();
  *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
+ *    runTest();
+ *  }
  */
-
-  /*
-   *@Test
-   *public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
-   *  runTest();
-   *}
-   */
 
   /*
    *@Test

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -18,104 +18,98 @@ public class APITest extends PythonTestBase {
 
   // Test params
 
-/*
- *  @Test
- *  public void testMethodWithBasicParams() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithBasicBoxedParams() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerBasicTypes() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithUserTypes() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testObjectParam() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testDataObjectParam() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testNullDataObjectParam() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerDataObject() throws Exception {
- *    runTest();
- *  }
- * 
- *  @Test
- *  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
- *    runTest();
- *  }
- *   
- *  @Test
- *  public void testMethodWithHandlerListAndSet() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerListVertxGen() throws Exception {
- *    runTest();
- *  }
- */
-/*
- *  @Test
- *  public void testMethodWithHandlerListAbstractVertxGen() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerUserTypes() throws Exception {
- *    runTest();
- *  }
- */
-/*
- *  @Test
- *  public void testMethodWithHandlerAsyncResultListVertxGen() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultListAbstractVertxGen() throws Exception {
- *    runTest();
- *  }
- */
+  @Test
+  public void testMethodWithBasicParams() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithBasicBoxedParams() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerBasicTypes() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithUserTypes() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testObjectParam() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testDataObjectParam() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testNullDataObjectParam() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerDataObject() throws Exception {
+    runTest();
+  }
+ 
+  @Test
+  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
+    runTest();
+  }
+   
+  @Test
+  public void testMethodWithHandlerListAndSet() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerListVertxGen() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMethodWithHandlerListAbstractVertxGen() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerUserTypes() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMethodWithHandlerAsyncResultListVertxGen() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultListAbstractVertxGen() throws Exception {
+    runTest();
+  }
 
   @Test
   public void testMethodWithHandlerSetVertxGen() throws Exception {

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -369,9 +369,9 @@ public class APITest extends PythonTestBase {
     runTest();
   }
    @Test
-  public void testMapComplexJsonArrayReturn() throws Exception {
-    runTest();
-  }
+   public void testMapComplexJsonArrayReturn() throws Exception {
+     runTest();
+   }
   @Test
   public void testOverloadedMethods() throws Exception {
     runTest();
@@ -414,136 +414,146 @@ public class APITest extends PythonTestBase {
   public void testMapReturn() throws Exception {
     runTest();
   }
- /*  @Test
- *  public void testMapStringReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMapJsonObjectReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMapComplexJsonObjectReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMapJsonArrayReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMapLongReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMapNullReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testListStringReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testListLongReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testListJsonObjectReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testListComplexJsonObjectReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testListJsonArrayReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testListComplexJsonArrayReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testListVertxGenReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testSetStringReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testSetLongReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testSetJsonObjectReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testSetComplexJsonObjectReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testSetJsonArrayReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testSetComplexJsonArrayReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testSetVertxGenReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*/
- /*  @Test
- *  public void testThrowableReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testCustomModule() throws Exception {
- *    runTest();
- *  }
+   @Test
+  public void testMapStringReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapJsonObjectReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapComplexJsonObjectReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMapJsonArrayReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapLongReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapIntegerReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapShortReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapByteReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapCharacterReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapBooleanReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapFloatReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapDoubleReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMapNullReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testListStringReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testListLongReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testListJsonObjectReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testListComplexJsonObjectReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testListJsonArrayReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testListComplexJsonArrayReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testListVertxGenReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testSetStringReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testSetLongReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testSetJsonObjectReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testSetComplexJsonObjectReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testSetJsonArrayReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testSetComplexJsonArrayReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testSetVertxGenReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testThrowableReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testCustomModule() throws Exception {
+    runTest();
+  }
+   
+  /*
+   *@Test
+   *public void testMethodWithListParams() throws Exception {
+   *  runTest();
+   *}
+   *@Test
+   *public void testMethodWithSetParams() throws Exception {
+   *  runTest();
+   *}
+   *@Test
+   *public void testMethodWithMapParams() throws Exception {
+   *  runTest();
+   *}
+   */
+
  /*  @Test
  *  public void testEnumReturn() throws Exception {
  *    runTest();
  *  }
- *
-  *  @Test
+ */
+  /*  @Test
   * public void testEnumParam() throws Exception {
-  *   runTest();
-  * }
-  *
-  *  @Test
-  * public void testMethodWithListParams() throws Exception {
-  *   runTest();
-  * }
-  *  @Test
-  * public void testMethodWithSetParams() throws Exception {
-  *   runTest();
-  * }
-  *  @Test
-  * public void testMethodWithMapParams() throws Exception {
   *   runTest();
   * }
   */

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -69,28 +69,27 @@ public class APITest extends PythonTestBase {
   }
 
  
-   @Test
-   public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
-     runTest();
-   }
-/*
- *  @Test
- *  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
- *    runTest();
- *  }
- */
+  @Test
+  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
+    runTest();
+  }
    
+  @Test
+  public void testMethodWithHandlerListAndSet() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
+    runTest();
+  }
+
  /*  @Test
- *  public void testMethodWithHandlerListAndSet() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
  *  public void testMethodWithHandlerListVertxGen() throws Exception {
  *    runTest();
  *  }

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -123,12 +123,12 @@ public class APITest extends PythonTestBase {
   public void testMethodWithHandlerAsyncResultSetVertxGen() throws Exception {
     runTest();
   }
-   @Test
-   public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
-     runTest();
-   }
- 
 
+  @Test
+  public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
+    runTest();
+  }
+ 
   @Test
   public void testMethodWithHandlerListJsonObject() throws Exception {
     runTest();
@@ -139,309 +139,266 @@ public class APITest extends PythonTestBase {
     runTest();
   }
 
-/*
- *  @Test
- *  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
- *    runTest();
- *  }
- */
+  @Test
+  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
+    runTest();
+  }
 
+  @Test
+  public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultListNullJsonObject() throws Exception {
+    runTest();
+  }
+
+
+  @Test
+  public void testMethodWithHandlerAsyncResultListComplexJsonObject() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerSetJsonObject() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerSetNullJsonObject() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultSetJsonObject() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMethodWithHandlerAsyncResultSetNullJsonObject() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMethodWithHandlerAsyncResultSetComplexJsonObject() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerListJsonArray() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMethodWithHandlerListNullJsonArray() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMethodWithHandlerListComplexJsonArray() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerSetJsonArray() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerSetNullJsonArray() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerSetComplexJsonArray() throws Exception {
+    runTest();
+  }
+
+   @Test
+  public void testMethodWithHandlerAsyncResultListJsonArray() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultListNullJsonArray() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultListComplexJsonArray() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultSetJsonArray() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultSetNullJsonArray() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultSetComplexJsonArray() throws Exception {
+    runTest();
+  }
+
+   @Test
+  public void testMethodWithHandlerListNullDataObject() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerListDataObject() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerSetDataObject() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerSetNullDataObject() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultListNullDataObject() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultListDataObject() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultSetDataObject() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultSetNullDataObject() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultUserTypes() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithConcreteHandlerUserTypeSubtype() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithAbstractHandlerUserTypeSubtype() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithConcreteHandlerUserTypeSubtypeExtension() throws Exception {
+    runTest();
+  }
+
+   @Test
+  public void testMethodWithHandlerVoid() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultVoid() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerAsyncResultVoidFails() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerThrowable() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithHandlerGenericUserType() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultGenericUserType() throws Exception {
+    runTest();
+  }
+
+   @Test
+  public void testMethodWithGenericParam() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithGenericHandler() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testMethodWithGenericHandlerAsyncResult() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testJsonParams() throws Exception {
+    runTest();
+  }
+   @Test
+   public void testNullJsonParams() throws Exception {
+     runTest();
+   }
+   @Test
+  public void testJsonHandlerParams() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testNullJsonHandlerParams() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testComplexJsonHandlerParams() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testJsonHandlerAsyncResultParams() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testNullJsonHandlerAsyncResultParams() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testComplexJsonHandlerAsyncResultParams() throws Exception {
+    runTest();
+  }
+   // Test returns
+   @Test
+  public void testBasicReturns() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testVertxGenReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testVertxGenNullReturn() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testAbstractVertxGenReturn() throws Exception {
+    runTest();
+  }
+
+ /*
+  *  @Test
+  * public void testEnumParam() throws Exception {
+  *   runTest();
+  * }
+  *
+  *  @Test
+  * public void testMethodWithListParams() throws Exception {
+  *   runTest();
+  * }
+  *  @Test
+  * public void testMethodWithSetParams() throws Exception {
+  *   runTest();
+  * }
+  *  @Test
+  * public void testMethodWithMapParams() throws Exception {
+  *   runTest();
+  * }
+  */
   /*
-   *@Test
-   *public void testMethodWithHandlerAsyncResultUserTypes() throws Exception {
+   * @Test
+   *public void testMapComplexJsonArrayReturn() throws Exception {
    *  runTest();
    *}
    */
- /*  @Test
- *  public void testMethodWithConcreteHandlerUserTypeSubtype() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithAbstractHandlerUserTypeSubtype() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerVoid() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultVoid() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultVoidFails() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerThrowable() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerGenericUserType() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultGenericUserType() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerSetJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerSetNullJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerSetComplexJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerListJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerListNullJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerListComplexJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerSetJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerSetNullJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerSetComplexJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerNullListDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerListDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerSetDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerNullSetDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultListComplexJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultListNullJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetNullJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetComplexJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultListJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultListNullJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultListComplexJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetNullJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetComplexJsonArray() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultNullListDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultListDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultNullSetDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithGenericParam() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithGenericHandler() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithGenericHandlerAsyncResult() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testJsonParams() throws Exception {
- *    runTest();
- *  }
- */
- /* // FIXME - temporarily commented out until we have proper support for nullable / not nullable params using
- * // codegen
- * //  @Test
- * //  public void testNullJsonParams() throws Exception {
- * //    runTest();
- * //  }
- */
- /*  @Test
- *  public void testJsonHandlerParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testNullJsonHandlerParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testComplexJsonHandlerParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testJsonHandlerAsyncResultParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testNullJsonHandlerAsyncResultParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testComplexJsonHandlerAsyncResultParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testEnumParam() throws Exception {
- *    runTest();
- *  }
- */
- /*/
- /*  @Test
- *  public void testMethodWithListParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithSetParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithMapParams() throws Exception {
- *    runTest();
- *  }
- */
- /*  // Test returns
- */
- /*  @Test
- *  public void testBasicReturns() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testVertxGenReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testVertxGenNullReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testAbstractVertxGenReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMapComplexJsonArrayReturn() throws Exception {
- *    runTest();
- *  }
- */
  /*  @Test
  *  public void testOverloadedMethods() throws Exception {
  *    runTest();

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -23,52 +23,50 @@ public class APITest extends PythonTestBase {
     runTest();
   }
 
-/*
- *  @Test
- *  public void testMethodWithBasicBoxedParams() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerBasicTypes() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithUserTypes() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testObjectParam() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testDataObjectParam() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testNullDataObjectParam() throws Exception {
- *    runTest();
- *  }
- *
- *  @Test
- *  public void testMethodWithHandlerDataObject() throws Exception {
- *    runTest();
- *  }
- */
+  @Test
+  public void testMethodWithBasicBoxedParams() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerBasicTypes() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithUserTypes() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testObjectParam() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testDataObjectParam() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testNullDataObjectParam() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerDataObject() throws Exception {
+    runTest();
+  }
 /*
  *
  *  @Test

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -1,0 +1,612 @@
+package io.vertx.test.lang.python;
+
+import org.junit.Test;
+
+/**
+ *
+ * This test tests all the different types of methods, return values and parameters that can be used in generated
+ * APIs.
+ *
+ * @author <a href="http://tfox.org">Dan O'Reilly</a>
+ */
+public class APITest extends PythonTestBase {
+
+  @Override
+  protected String getTestFile() {
+    return "api_test.py";
+  }
+
+  // Test params
+
+  @Test
+  public void testMethodWithBasicParams() throws Exception {
+    runTest();
+  }
+
+/*
+ *  @Test
+ *  public void testMethodWithBasicBoxedParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerBasicTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultBasicTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultBasicTypesFails() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithUserTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testObjectParam() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testDataObjectParam() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testNullDataObjectParam() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerDataObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+/*
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultDataObjectFails() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListAndSet() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListAndSet() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerUserTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultUserTypes() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithConcreteHandlerUserTypeSubtype() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithAbstractHandlerUserTypeSubtype() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerVoid() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultVoid() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultVoidFails() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerThrowable() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerGenericUserType() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultGenericUserType() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerNullListDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerSetDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerNullSetDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetNullJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetComplexJsonArray() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultNullListDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultListDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultSetDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerAsyncResultNullSetDataObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithGenericParam() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithGenericHandler() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithGenericHandlerAsyncResult() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testJsonParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ * // FIXME - temporarily commented out until we have proper support for nullable / not nullable params using
+ * // codegen
+ * //  @Test
+ * //  public void testNullJsonParams() throws Exception {
+ * //    runTest();
+ * //  }
+ *
+ *  @Test
+ *  public void testJsonHandlerParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testNullJsonHandlerParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testComplexJsonHandlerParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testJsonHandlerAsyncResultParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testNullJsonHandlerAsyncResultParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testComplexJsonHandlerAsyncResultParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testEnumParam() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *
+ *  @Test
+ *  public void testMethodWithListParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithSetParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithMapParams() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  // Test returns
+ *
+ *  @Test
+ *  public void testBasicReturns() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testVertxGenReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testVertxGenNullReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testAbstractVertxGenReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMapComplexJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testOverloadedMethods() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSuperInterfaces() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithGenericReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testFluentMethod() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testStaticFactoryMethod() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithCachedReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testJsonReturns() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testNullJsonReturns() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *
+ *
+ *  @Test
+ *  public void testEnumReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMapReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMapStringReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMapJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMapComplexJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMapJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMapLongReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMapNullReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testListStringReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testListLongReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testListJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testListComplexJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testListJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testListComplexJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testListVertxGenReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSetStringReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSetLongReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSetJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSetComplexJsonObjectReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSetJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSetComplexJsonArrayReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testSetVertxGenReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *
+ *  @Test
+ *  public void testThrowableReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testCustomModule() throws Exception {
+ *    runTest();
+ *  }
+ */
+}

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -116,6 +116,44 @@ public class APITest extends PythonTestBase {
     runTest();
   }
 
+  @Test
+  public void testMethodWithHandlerSetAbstractVertxGen() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerAsyncResultSetVertxGen() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithHandlerListJsonObject() throws Exception {
+    runTest();
+  }
+
+/*
+ *  @Test
+ *  public void testMethodWithHandlerListNullJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ *
+ *  @Test
+ *  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
+ *    runTest();
+ *  }
+ */
+
+  /*
+   *@Test
+   *public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
+   *  runTest();
+   *}
+   */
+
   /*
    *@Test
    *public void testMethodWithHandlerAsyncResultUserTypes() throws Exception {
@@ -159,26 +197,6 @@ public class APITest extends PythonTestBase {
  */
  /*  @Test
  *  public void testMethodWithHandlerAsyncResultGenericUserType() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerSetAbstractVertxGen() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerListJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerListNullJsonObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerListComplexJsonObject() throws Exception {
  *    runTest();
  *  }
  */
@@ -244,21 +262,6 @@ public class APITest extends PythonTestBase {
  */
  /*  @Test
  *  public void testMethodWithHandlerNullSetDataObject() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetVertxGen() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultSetAbstractVertxGen() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithHandlerAsyncResultListJsonObject() throws Exception {
  *    runTest();
  *  }
  */

--- a/src/test/java/io/vertx/test/lang/python/APITest.java
+++ b/src/test/java/io/vertx/test/lang/python/APITest.java
@@ -368,82 +368,52 @@ public class APITest extends PythonTestBase {
   public void testAbstractVertxGenReturn() throws Exception {
     runTest();
   }
-
- /*
-  *  @Test
-  * public void testEnumParam() throws Exception {
-  *   runTest();
-  * }
-  *
-  *  @Test
-  * public void testMethodWithListParams() throws Exception {
-  *   runTest();
-  * }
-  *  @Test
-  * public void testMethodWithSetParams() throws Exception {
-  *   runTest();
-  * }
-  *  @Test
-  * public void testMethodWithMapParams() throws Exception {
-  *   runTest();
-  * }
-  */
    @Test
   public void testMapComplexJsonArrayReturn() throws Exception {
     runTest();
   }
- /*  @Test
- *  public void testOverloadedMethods() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testSuperInterfaces() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithGenericReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testFluentMethod() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testStaticFactoryMethod() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMethodWithCachedReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testJsonReturns() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testNullJsonReturns() throws Exception {
- *    runTest();
- *  }
- */
- /*/
- /*/
- /*  @Test
- *  public void testEnumReturn() throws Exception {
- *    runTest();
- *  }
- */
- /*  @Test
- *  public void testMapReturn() throws Exception {
- *    runTest();
- *  }
- */
+  @Test
+  public void testOverloadedMethods() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testSuperInterfaces() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithGenericReturn() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testFluentMethod() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testStaticFactoryMethod() throws Exception {
+    runTest();
+  }
+
+  @Test
+  public void testMethodWithCachedReturn() throws Exception {
+    runTest();
+  }
+  @Test
+  public void testJsonReturns() throws Exception {
+    runTest();
+  }
+   @Test
+  public void testNullJsonReturns() throws Exception {
+    runTest();
+  }
+ 
+  @Test
+  public void testMapReturn() throws Exception {
+    runTest();
+  }
  /*  @Test
  *  public void testMapStringReturn() throws Exception {
  *    runTest();
@@ -554,7 +524,29 @@ public class APITest extends PythonTestBase {
  *  public void testCustomModule() throws Exception {
  *    runTest();
  *  }
- */
+ /*  @Test
+ *  public void testEnumReturn() throws Exception {
+ *    runTest();
+ *  }
+ *
+  *  @Test
+  * public void testEnumParam() throws Exception {
+  *   runTest();
+  * }
+  *
+  *  @Test
+  * public void testMethodWithListParams() throws Exception {
+  *   runTest();
+  * }
+  *  @Test
+  * public void testMethodWithSetParams() throws Exception {
+  *   runTest();
+  * }
+  *  @Test
+  * public void testMethodWithMapParams() throws Exception {
+  *   runTest();
+  * }
+  */
    // This one is disabled because we can't pass a null data object
   // To the Python API.
    //@Test

--- a/src/test/java/io/vertx/test/lang/python/PythonRunner.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonRunner.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.lang.ProcessBuilder.Redirect;
 import java.net.InetAddress;
 import java.io.IOException;
+import java.util.Map;
 
 import io.vertx.core.Vertx;
 
@@ -62,6 +63,8 @@ public class PythonRunner {
                                            String.valueOf(port), 
                                            String.valueOf(client_port), 
                                            testName);
+    Map<String, String> env = pb.environment();
+    env.put("PYTHONPATH", "src/main/resources");
     pb.redirectOutput(Redirect.INHERIT);
     pb.redirectError(Redirect.INHERIT);
     Process process = pb.start();

--- a/src/test/java/io/vertx/test/lang/python/PythonRunner.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonRunner.java
@@ -1,0 +1,72 @@
+package io.vertx.test.lang.python;
+
+import java.io.File;
+import java.net.URL;
+import java.lang.ProcessBuilder.Redirect;
+import java.net.InetAddress;
+import java.io.IOException;
+
+import io.vertx.core.Vertx;
+
+import py4j.GatewayServer;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class PythonRunner {
+
+  private static GatewayServer gateway;
+  private static int global_port = 25333;
+  private static int global_client_port = 24333;
+  private int port;
+  private int client_port;
+  private Process Process;
+
+  public static void main(String[] args) {
+  }
+
+  public Vertx getVertx() {
+    return Vertx.vertx();
+  }
+
+  public void start_gateway() throws Exception {
+    if (gateway == null){
+      boolean connected = false;
+      while (!connected) {
+        try {
+          gateway = new GatewayServer(new PythonRunner(), global_port, global_client_port,
+                                      InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS),
+                                      InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS),
+                                      GatewayServer.DEFAULT_CONNECT_TIMEOUT,
+                                      GatewayServer.DEFAULT_READ_TIMEOUT,
+                                      null
+                                      );
+          gateway.start();
+          connected = true;
+          port = global_port++;
+          client_port = global_client_port++;
+        } catch (Exception e) {
+          global_port++;
+          global_client_port++;
+        }
+        if (port > 25440) {
+          throw new Exception("Failed to bind to port");
+        }
+      }
+    }
+  }
+
+  public void run(String scriptName, String testName) throws Exception {
+    run(scriptName, testName, true, true);
+  }
+
+  public void run(String scriptName, String testName, 
+                  boolean provideRequire, boolean provideConsole) throws Exception {
+    ProcessBuilder pb = new ProcessBuilder("python", scriptName, String.valueOf(port), String.valueOf(client_port), testName);
+    pb.redirectOutput(Redirect.INHERIT);
+    pb.redirectError(Redirect.INHERIT);
+    Process process = pb.start();
+    int out = process.waitFor();
+  }
+
+}

--- a/src/test/java/io/vertx/test/lang/python/PythonRunner.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonRunner.java
@@ -15,13 +15,9 @@ import py4j.GatewayServer;
  */
 public class PythonRunner {
 
-  private static GatewayServer gateway;
-  private static int port = 25333;
-  private static int client_port = 24333;
-  /*
-   *private int port;
-   *private int client_port;
-   */
+  private GatewayServer gateway;
+  private int port = 25333;
+  private int client_port = 24333;
   private Process Process;
 
   public static void main(String[] args) {
@@ -31,9 +27,8 @@ public class PythonRunner {
     return Vertx.vertx();
   }
 
-  public static void start_gateway() throws Exception {
+  public void start_gateway() throws Exception {
     if (gateway == null) {
-      System.out.println("STARTING GATEWAY");
       boolean connected = false;
       while (!connected) {
         try {
@@ -71,10 +66,8 @@ public class PythonRunner {
     pb.redirectError(Redirect.INHERIT);
     Process process = pb.start();
     int out = process.waitFor();
-    /*
-     *gateway.shutdown();
-     *gateway = null;
-     */
+    gateway.shutdown();
+    gateway = null;
     return out;
       
   }

--- a/src/test/java/io/vertx/test/lang/python/PythonRunner.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonRunner.java
@@ -16,10 +16,12 @@ import py4j.GatewayServer;
 public class PythonRunner {
 
   private static GatewayServer gateway;
-  private static int global_port = 25333;
-  private static int global_client_port = 24333;
-  private int port;
-  private int client_port;
+  private static int port = 25333;
+  private static int client_port = 24333;
+  /*
+   *private int port;
+   *private int client_port;
+   */
   private Process Process;
 
   public static void main(String[] args) {
@@ -29,12 +31,12 @@ public class PythonRunner {
     return Vertx.vertx();
   }
 
-  public void start_gateway() throws Exception {
+  public static void start_gateway() throws Exception {
     if (gateway == null){
       boolean connected = false;
       while (!connected) {
         try {
-          gateway = new GatewayServer(new PythonRunner(), global_port, global_client_port,
+          gateway = new GatewayServer(new PythonRunner(), port, client_port,
                                       InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS),
                                       InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS),
                                       GatewayServer.DEFAULT_CONNECT_TIMEOUT,
@@ -43,11 +45,9 @@ public class PythonRunner {
                                       );
           gateway.start();
           connected = true;
-          port = global_port++;
-          client_port = global_client_port++;
         } catch (Exception e) {
-          global_port++;
-          global_client_port++;
+          port++;
+          client_port++;
         }
         if (port > 25440) {
           throw new Exception("Failed to bind to port");
@@ -56,17 +56,25 @@ public class PythonRunner {
     }
   }
 
-  public void run(String scriptName, String testName) throws Exception {
-    run(scriptName, testName, true, true);
+  public int run(String scriptName, String testName) throws Exception {
+    return run(scriptName, testName, true, true);
   }
 
-  public void run(String scriptName, String testName, 
-                  boolean provideRequire, boolean provideConsole) throws Exception {
-    ProcessBuilder pb = new ProcessBuilder("python", "-u", scriptName, String.valueOf(port), String.valueOf(client_port), testName);
+  public int run(String scriptName, String testName, boolean provideRequire, 
+                 boolean provideConsole) throws Exception {
+    ProcessBuilder pb = new ProcessBuilder("python", "-u", scriptName, 
+                                           String.valueOf(port), 
+                                           String.valueOf(client_port), 
+                                           testName);
     pb.redirectOutput(Redirect.INHERIT);
     pb.redirectError(Redirect.INHERIT);
     Process process = pb.start();
     int out = process.waitFor();
+    /*
+     *gateway.shutdown();
+     *gateway = null;
+     */
+    return out;
+      
   }
-
 }

--- a/src/test/java/io/vertx/test/lang/python/PythonRunner.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonRunner.java
@@ -32,7 +32,8 @@ public class PythonRunner {
   }
 
   public static void start_gateway() throws Exception {
-    if (gateway == null){
+    if (gateway == null) {
+      System.out.println("STARTING GATEWAY");
       boolean connected = false;
       while (!connected) {
         try {

--- a/src/test/java/io/vertx/test/lang/python/PythonRunner.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonRunner.java
@@ -62,7 +62,7 @@ public class PythonRunner {
 
   public void run(String scriptName, String testName, 
                   boolean provideRequire, boolean provideConsole) throws Exception {
-    ProcessBuilder pb = new ProcessBuilder("python", scriptName, String.valueOf(port), String.valueOf(client_port), testName);
+    ProcessBuilder pb = new ProcessBuilder("python", "-u", scriptName, String.valueOf(port), String.valueOf(client_port), testName);
     pb.redirectOutput(Redirect.INHERIT);
     pb.redirectError(Redirect.INHERIT);
     Process process = pb.start();

--- a/src/test/java/io/vertx/test/lang/python/PythonTestBase.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonTestBase.java
@@ -1,0 +1,27 @@
+package io.vertx.test.lang.python;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public abstract class PythonTestBase {
+
+  protected String getMethodName() {
+    return Thread.currentThread().getStackTrace()[3].getMethodName();
+  }
+
+  protected abstract String getTestFile();
+
+  protected void runTest() throws Exception {
+    PythonRunner runner = new PythonRunner();
+    runner.start_gateway();
+    try {
+      TimeUnit.MILLISECONDS.sleep(2000);
+    } catch (InterruptedException ex) { }
+    String path = "src/test/resources/" + getTestFile();
+    runner.run(path, getMethodName());
+  }
+}

--- a/src/test/java/io/vertx/test/lang/python/PythonTestBase.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonTestBase.java
@@ -19,10 +19,7 @@ public abstract class PythonTestBase {
 
   protected void runTest() throws Exception {
     PythonRunner runner = new PythonRunner();
-    PythonRunner.start_gateway();
-    try {
-      TimeUnit.MILLISECONDS.sleep(2000);
-    } catch (InterruptedException ex) { }
+    runner.start_gateway();
     String path = "src/test/resources/" + getTestFile();
     int out = runner.run(path, getMethodName());
     Assert.assertEquals("Test return value indicates failure", out, 0);

--- a/src/test/java/io/vertx/test/lang/python/PythonTestBase.java
+++ b/src/test/java/io/vertx/test/lang/python/PythonTestBase.java
@@ -4,6 +4,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Assert;
+
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
@@ -17,11 +19,12 @@ public abstract class PythonTestBase {
 
   protected void runTest() throws Exception {
     PythonRunner runner = new PythonRunner();
-    runner.start_gateway();
+    PythonRunner.start_gateway();
     try {
       TimeUnit.MILLISECONDS.sleep(2000);
     } catch (InterruptedException ex) { }
     String path = "src/test/resources/" + getTestFile();
-    runner.run(path, getMethodName());
+    int out = runner.run(path, getMethodName());
+    Assert.assertEquals("Test return value indicates failure", out, 0);
   }
 }

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1,7 +1,4 @@
 import sys
-import atexit
-
-from py4j.java_gateway import JavaGateway, GatewayClient
 
 from testmodel_python.testmodel.test_interface import TestInterface
 from testmodel_python.testmodel.refed_interface1 import RefedInterface1
@@ -13,12 +10,12 @@ from vertx_python import util
 
 util.vertx_init()
 
-jvm = util.jvm
-
-Assert = jvm.org.junit.Assert;
-obj = TestInterface(jvm.io.vertx.codegen.testmodel.TestInterfaceImpl())
-refed_obj = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
-refed_obj2 = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
+with util.handle_java_error():
+    jvm = util.jvm
+    Assert = jvm.org.junit.Assert;
+    obj = TestInterface(jvm.io.vertx.codegen.testmodel.TestInterfaceImpl())
+    refed_obj = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
+    refed_obj2 = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
 
 def testMethodWithBasicParams():
     print("MADE IT TO HERE")
@@ -1415,4 +1412,5 @@ def testMethodWithHandlerDataObject():
 if __name__ == "__main__":
     meth = sys.argv[3]
     print("calling {}".format(meth))
-    globals()[meth]()
+    with util.handle_java_error():
+        globals()[meth]()

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1,0 +1,1418 @@
+import sys
+import atexit
+
+from py4j.java_gateway import JavaGateway, GatewayClient
+
+from testmodel_python.testmodel.test_interface import TestInterface
+from testmodel_python.testmodel.refed_interface1 import RefedInterface1
+from testmodel_python.testmodel.factory import Factory
+from acme_python.pkg.my_interface import MyInterface
+from acme_python.sub.sub_interface import SubInterface
+
+from vertx_python import util
+
+util.vertx_init()
+
+jvm = util.jvm
+
+Assert = jvm.org.junit.Assert;
+obj = TestInterface(jvm.io.vertx.codegen.testmodel.TestInterfaceImpl())
+refed_obj = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
+refed_obj2 = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
+
+def testMethodWithBasicParams():
+    print("MADE IT TO HERE")
+    obj.method_with_basic_params(b'123', 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88, 'foobar')
+
+
+def testMethodWithBasicBoxedParams():
+    obj.method_with_basic_boxed_params(b'123', 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88)
+
+
+def testMethodWithHandlerBasicTypes():
+    dct = dict(count=0)
+    def byte_handler(b):
+        Assert.assertEquals(type(b), int)
+        Assert.assertEquals(123, b, 0)
+        dct['count'] += 1
+    def short_handler(s):
+        Assert.assertEquals(type(s), int)
+        Assert.assertEquals(12345, s, 0)
+        dct['count'] += 1
+    def int_handler(i):
+        Assert.assertEquals(type(i), int)
+        Assert.assertEquals(1234567, i, 0)
+        dct['count'] += 1
+    def long_handler(l):
+        Assert.assertEquals(type(l), long)
+        Assert.assertEquals(1265615234, l, 0)
+        dct['count'] += 1
+    def float_handler(f):
+        Assert.assertEquals(type(f), float)
+        Assert.assertEquals(12.345, f, 0)
+        dct['count'] += 1
+    def double_handler(d):
+        Assert.assertEquals(type(d), float)
+        Assert.assertEquals(12.34566, d, 0)
+        dct['count'] += 1
+    def boolean_handler(b):
+        Assert.assertEquals(type(b), bool)
+        Assert.assertTrue(b)
+        dct['count'] += 1
+    def char_handler(c):
+        Assert.assertEquals(type(c), str)
+        Assert.assertEquals('X', c)
+        dct['count'] += 1
+    def string_handler(s):
+        Assert.assertEquals(type(s), str)
+        Assert.assertEquals('quux!', str)
+        dct['count'] += 1
+
+    obj.methodWithHandlerBasicTypes(byte_handler, short_handler, int_handler, long_handler,
+                                    float_handler, double_handler, boolean_handler, char_handler,
+                                    string_handler)
+    Assert.assertEquals(dct['count'], 9, 0)
+          
+def testMethodWithHandlerAsyncResultBasicTypes():
+    dct = dict(count=0)
+    def byte_handler(b, err):
+        Assert.assertEquals(type(b), int)
+        Assert.assertEquals(123, b, 0)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    def short_handler(s, err):
+        Assert.assertEquals(type(s), int)
+        Assert.assertEquals(12345, s, 0)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    def int_handler(i, err):
+        Assert.assertEquals(type(i), int)
+        Assert.assertEquals(1234567, i, 0)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    def long_handler(l, err):
+        Assert.assertEquals(type(l), long)
+        Assert.assertEquals(1265615234l, l, 0)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    def float_handler(f, err):
+        Assert.assertEquals(type(f), float)
+        Assert.assertEquals(12.345, f, 0)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    def double_handler(d, err):
+        Assert.assertEquals(type(d), float)
+        Assert.assertEquals(12.34566, d, 0)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    def boolean_handler(b, err):
+        Assert.assertEquals(type(b), bool)
+        Assert.assertTrue(b)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    def char_handler(c, err):
+        Assert.assertEquals(type(c), str)
+        Assert.assertEquals('X', c)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    def string_handler(s, err):
+        Assert.assertEquals(type(s), str)
+        Assert.assertEquals('quux!', str)
+        Assert.assertNull(err)
+        dct['count'] += 1
+    obj.method_with_handler_async_result_byte(False, byte_handler)
+    obj.method_with_handler_async_result_short(False, byte_handler)
+    obj.method_with_handler_async_result_integer(False, byte_handler)
+    obj.method_with_handler_async_result_long(False, long_handler)
+    obj.method_with_handler_async_result_float(False, float_handler)
+    obj.method_with_handler_async_result_double(False, double_handler)
+    obj.method_with_handler_async_result_boolean(False, boolean_handler)
+    obj.method_with_handler_async_result_char(False, char_handler)
+    obj.method_with_handler_async_result_string(False, string_handler)
+    Assert.assertEquals(dct['count'], 9, 0)
+
+
+def testMethodWithHandlerAsyncResultBasicTypesFails():
+    dct = dict(count=0)
+    def handler(x, err):
+        Assert.assertNull(x);
+        Assert.assertNotNull(err);
+        Assert.assertEquals("foobar!", err.getMessage());
+        dct['count'] += 1
+
+    obj.method_with_handler_async_result_byte(True, handler)
+    obj.method_with_handler_async_result_short(True, handler)
+    obj.method_with_handler_async_result_integer(True, handler)
+    obj.method_with_handler_async_result_long(True, handler)
+    obj.method_with_handler_async_result_float(True, handler)
+    obj.method_with_handler_async_result_double(True, handler)
+    obj.method_with_handler_async_result_boolean(True, handler)
+    obj.method_with_handler_async_result_char(True, handler)
+    obj.method_with_handler_async_result_string(True, handler)
+    Assert.assertEquals(dct['count'], 9, 0)
+
+def testMethodWithUserTypes():
+    refed_obj.set_string('aardvarks')
+    obj.method_with_user_types(refed_obj)
+
+
+def testObjectParam():
+    obj.method_with_object_param('null', None)
+    obj.method_with_object_param('string', 'wibble')
+    obj.method_with_object_param('true', True)
+    obj.method_with_object_param('false', False)
+    obj.method_with_object_param('long', 123)
+    obj.method_with_object_param('double', 123.456)
+    json_obj = {"foo" : "hello", "bar" : 123}
+    obj.method_with_object_param('JsonObject', json_obj)
+    json_arr = ["foo", "bar", "wib"]
+    obj.method_with_object_param('JsonArray', json_arr)
+
+
+def testDataObjectParam():
+    data_object = {"foo" : "Hello", "bar" : 123, "wibble" : 1.23}
+    obj.method_with_data_object_param(data_object)
+
+
+def testNullDataObjectParam():
+    obj.method_with_null_data_object_param(None);
+
+
+def testMethodWithHandlerDataObject():
+    dct = dict(count=0)
+    def handler(option):
+        Assert.assertEquals("foo", option.foo)
+        Assert.assertEquals(123, option.bar, 0)
+        Assert.assertEquals(0.0, option.wibble, 0)
+        dct['count'] += 1
+    obj.method_with_handler_data_object(handler)
+    Assert.assertEquals(dct['count'], 1, 0)
+
+
+#def testMethodWithHandlerAsyncResultDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_data_object(false) { |err,val| Assert.is_nil(err); Assert.equals(val, {'foo' => 'foo', 'bar' => 123, 'wibble' => 0.0}); dct['count'] += 1 }
+    #Assert.equals(count, 1)
+
+
+#def testMethodWithHandlerAsyncResultDataObjectFails():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_data_object(true) { |err,val| Assert.is_nil(val); Assert.is_not_nil(err); Assert.equals(err.message, 'foobar!'); dct['count'] += 1 }
+    #Assert.equals(count, 1)
+
+
+#def testMethodWithHandlerListAndSet():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_and_set(
+        #Proc.new { |val| Assert.equals(val, %w(foo bar wibble)); dct['count'] += 1 },
+        #Proc.new { |val| Assert.equals(val, [5,12,100]); dct['count'] += 1 },
+        #Proc.new { |val| Assert.equals(val, Set.new(%w(foo bar wibble))); dct['count'] += 1 }) do |val|
+      #Assert.equals(val, Set.new([5,12,100])); dct['count'] += 1
+    #end
+    #Assert.equals(4, count)
+
+
+#def testMethodWithHandlerAsyncResultListAndSet():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_string { |err,val| Assert.is_nil(err); Assert.equals(val, %w(foo bar wibble)); dct['count'] += 1 }
+    #obj.method_with_handler_async_result_list_integer { |err,val| Assert.is_nil(err); Assert.equals(val, [5,12,100]); dct['count'] += 1 }
+    #obj.method_with_handler_async_result_set_string { |err,val| Assert.is_nil(err); Assert.equals(val, Set.new(%w(foo bar wibble))); dct['count'] += 1 }
+    #obj.method_with_handler_async_result_set_integer { |err,val| Assert.is_nil(err); Assert.equals(val, Set.new([5,12,100])); dct['count'] += 1 }
+    #Assert.equals(4, count)
+
+
+#def testMethodWithHandlerListVertxGen():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_vertx_gen do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 2)
+      #Assert.equals(val[0].class, Testmodel::RefedInterface1)
+      #Assert.equals(val[0].get_string, 'foo')
+      #Assert.equals(val[1].class, Testmodel::RefedInterface1)
+      #Assert.equals(val[1].get_string, 'bar')
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListAbstractVertxGen():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_abstract_vertx_gen do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 2)
+      #Assert.equals(val[0].is_a?(Testmodel::RefedInterface2), true)
+      #Assert.equals(val[0].get_string, 'abstractfoo')
+      #Assert.equals(val[1].is_a?(Testmodel::RefedInterface2), true)
+      #Assert.equals(val[1].get_string, 'abstractbar')
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListVertxGen():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_vertx_gen do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 2)
+      #Assert.equals(val[0].class, Testmodel::RefedInterface1)
+      #Assert.equals(val[0].get_string, 'foo')
+      #Assert.equals(val[1].class, Testmodel::RefedInterface1)
+      #Assert.equals(val[1].get_string, 'bar')
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListAbstractVertxGen():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_abstract_vertx_gen do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 2)
+      #Assert.equals(val[0].is_a?(Testmodel::RefedInterface2), true)
+      #Assert.equals(val[0].get_string, 'abstractfoo')
+      #Assert.equals(val[1].is_a?(Testmodel::RefedInterface2), true)
+      #Assert.equals(val[1].get_string, 'abstractbar')
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetVertxGen():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_vertx_gen do |val|
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 2)
+      #val.each { |elt| Assert.equals(elt.class, Testmodel::RefedInterface1) }
+      #Assert.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetAbstractVertxGen():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_abstract_vertx_gen do |val|
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 2)
+      #val.each { |elt| Assert.equals(elt.is_a?(Testmodel::RefedInterface2), true) }
+      #Assert.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(abstractfoo abstractbar)))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetVertxGen():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_vertx_gen do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 2)
+      #val.each { |elt| Assert.equals(elt.class, Testmodel::RefedInterface1) }
+      #Assert.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetAbstractVertxGen():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_abstract_vertx_gen do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 2)
+      #val.each { |elt| Assert.equals(elt.is_a?(Testmodel::RefedInterface2), true) }
+      #Assert.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(abstractfoo abstractbar)))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_json_object do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 2)
+      #Assert.equals(val[0].class, Hash)
+      #Assert.equals(val[0], {'cheese' => 'stilton'})
+      #Assert.equals(val[1].class, Hash)
+      #Assert.equals(val[1], {'socks' => 'tartan'})
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListNullJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_null_json_object do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 1)
+      #Assert.equals(val[0], nil)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListComplexJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_complex_json_object do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 1)
+      #Assert.equals(val[0], {'outer' => {'socks' => 'tartan'}, 'list' => ['yellow', 'blue']})
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_json_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 2)
+      #Assert.equals(val[0].class, Hash)
+      #Assert.equals(val[0], {'cheese' => 'stilton'})
+      #Assert.equals(val[1].class, Hash)
+      #Assert.equals(val[1], {'socks' => 'tartan'})
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListNullJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_null_json_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 1)
+      #Assert.equals(val[0], nil)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListComplexJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_complex_json_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 1)
+      #Assert.equals(val[0], {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']})
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_json_object do |val|
+      #Assert.equals(val.class, Set)
+      #val.each { |elt| Assert.equals(elt.is_a?(Hash), true) }
+      #Assert.equals(val, Set.new([{'cheese' => 'stilton'},{'socks' => 'tartan'}]))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetNullJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_null_json_object do |val|
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 1)
+      #val.each { |elt| Assert.is_nil(elt) }
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetComplexJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_complex_json_object do |val|
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 1)
+      #Assert.equals(val, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_json_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Set)
+      #val.each { |elt| Assert.equals(elt.is_a?(Hash), true) }
+      #Assert.equals(val, Set.new([{'cheese' => 'stilton'},{'socks' => 'tartan'}]))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetNullJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_null_json_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 1)
+      #val.each { |elt| Assert.is_nil(elt) }
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetComplexJsonObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_complex_json_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 1)
+      #Assert.equals(val, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_json_array do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 2)
+      #Assert.equals(val[0].class, Array)
+      #Assert.equals(val[0], %w(green blue))
+      #Assert.equals(val[1].class, Array)
+      #Assert.equals(val[1], %w(yellow purple))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListNullJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_null_json_array do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 1)
+      #Assert.equals(val[0], nil)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_json_array do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 2)
+      #Assert.equals(val[0].class, Array)
+      #Assert.equals(val[0], %w(green blue))
+      #Assert.equals(val[1].class, Array)
+      #Assert.equals(val[1], %w(yellow purple))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListNullJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_null_json_array do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val.size, 1)
+      #Assert.equals(val[0], nil)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListComplexJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_complex_json_array do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_json_array do |val|
+      #Assert.equals(val.class, Set)
+      #val.each { |elt| Assert.equals(elt.is_a?(Array), true) }
+      #Assert.equals(val, Set.new([%w(green blue), %w(yellow purple)]))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetNullJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_null_json_array do |val|
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 1)
+      #val.each { |elt| Assert.is_nil(elt) }
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetComplexJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_complex_json_array do |val|
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_json_array do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Set)
+      #val.each { |elt| Assert.equals(elt.is_a?(Array), true) }
+      #Assert.equals(val, Set.new([%w(green blue), %w(yellow purple)]))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetNullJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_null_json_array do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val.size, 1)
+      #val.each { |elt| Assert.is_nil(elt) }
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListComplexJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_complex_json_array do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_data_object do |val|
+      #Assert.equals(val.class, Array)
+      #val.each { |elt| Assert.equals(elt.is_a?(Hash), true) }
+      #Assert.equals(val[0], {'foo'=>'String 1','bar'=>1,'wibble'=>1.1})
+      #Assert.equals(val[1], {'foo'=>'String 2','bar'=>2,'wibble'=>2.2})
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerListNullDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_list_null_data_object do |val|
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val[0], nil)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerSetDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_data_object do |val|
+      #Assert.equals(val, Set.new([{'foo'=>'String 1','bar'=>1,'wibble'=>1.1},{'foo'=>'String 2','bar'=>2,'wibble'=>2.2}]))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerNullSetDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_set_null_data_object do |val|
+      #Assert.equals(val, Set.new([nil]))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetComplexJsonArray():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_complex_json_array do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Set)
+      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_data_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #val.each { |elt| Assert.equals(elt.is_a?(Hash), true) }
+      #Assert.equals(val[0], {'foo'=>'String 1','bar'=>1,'wibble'=>1.1})
+      #Assert.equals(val[1], {'foo'=>'String 2','bar'=>2,'wibble'=>2.2})
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultListNullDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_list_null_data_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Array)
+      #Assert.equals(val[0], nil)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultSetDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_data_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val, Set.new([{'foo'=>'String 1','bar'=>1,'wibble'=>1.1},{'foo'=>'String 2','bar'=>2,'wibble'=>2.2}]))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultNullSetDataObject():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_set_null_data_object do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val, Set.new([nil]))
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerUserTypes():
+    #dct = dict(count=0)
+    #obj.method_with_handler_user_types do |val|
+      #Assert.equals(val.class, Testmodel::RefedInterface1)
+      #Assert.equals(val.get_string, 'echidnas')
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultUserTypes():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_user_types do |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val.class, Testmodel::RefedInterface1)
+      #Assert.equals(val.get_string, 'cheetahs')
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithConcreteHandlerUserTypeSubtype():
+    #dct = dict(count=0)
+    #arg = Testmodel::Factory.create_concrete_handler_user_type do |refedObj|
+      #Assert.equals(refedObj.class, Testmodel::RefedInterface1)
+      #Assert.equals(refedObj.get_string, 'echidnas')
+      #dct['count'] += 1
+    #end
+    #obj.method_with_concrete_handler_user_type_subtype arg
+    #Assert.equals(1, count)
+
+
+#def testMethodWithAbstractHandlerUserTypeSubtype():
+    #dct = dict(count=0)
+    #arg = Testmodel::Factory.create_abstract_handler_user_type do |refedObj|
+      #Assert.equals(refedObj.class, Testmodel::RefedInterface1)
+      #Assert.equals(refedObj.get_string, 'echidnas')
+      #dct['count'] += 1
+    #end
+    #obj.method_with_abstract_handler_user_type_subtype arg
+    #Assert.equals(1, count)
+
+
+#def testMethodWithConcreteHandlerUserTypeSubtypeExtension():
+    #dct = dict(count=0)
+    #arg = Testmodel::Factory.create_concrete_handler_user_type_extension do |refedObj|
+      #Assert.equals(refedObj.class, Testmodel::RefedInterface1)
+      #Assert.equals(refedObj.get_string, 'echidnas')
+      #dct['count'] += 1
+    #end
+    #obj.method_with_concrete_handler_user_type_subtype_extension arg
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerVoid():
+    #dct = dict(count=0)
+    #obj.method_with_handler_void do |val|
+      #Assert.is_nil(val)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultVoid():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_void(false) do |err|
+      #Assert.is_nil(err)
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerAsyncResultVoidFails():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_void(true) do |err|
+      #Assert.is_not_nil err
+      #Assert.equals(err.message, 'foo!')
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerThrowable():
+    #dct = dict(count=0)
+    #obj.method_with_handler_throwable do |err|
+      #Assert.is_not_nil err
+      #Assert.equals(err.message, 'cheese!')
+      #dct['count'] += 1
+    #end
+    #Assert.equals(1, count)
+
+
+#def testMethodWithHandlerGenericUserType():
+    #def run_test(value, &assert)():
+      #dct = dict(count=0)
+      #obj.method_with_handler_generic_user_type(value) do |refedObj|
+        #Assert.is_not_nil(refedObj)
+        #Assert.equals(refedObj.class, Testmodel::GenericRefedInterface)
+        #assert.call(refedObj.get_value)
+        #dct['count'] += 1
+      #end
+      #Assert.equals(1, count)
+    #end
+    #run_test('string_value') { |value| Assert.equals(value, 'string_value') }
+    #run_test({'key' => 'key_value'}) { |value| Assert.equals(value, {'key' => 'key_value'}) }
+    #run_test(%w(foo bar juu)) { |value| Assert.equals(value, %w(foo bar juu)) }
+
+
+#def testMethodWithHandlerAsyncResultGenericUserType():
+    #def run_test(value, &assert)():
+      #dct = dict(count=0)
+      #obj.method_with_handler_async_result_generic_user_type(value) do |err,refedObj|
+        #Assert.is_nil(err)
+        #Assert.is_not_nil(refedObj)
+        #Assert.equals(refedObj.class, Testmodel::GenericRefedInterface)
+        #assert.call(refedObj.get_value)
+        #dct['count'] += 1
+      #end
+      #Assert.equals(1, count)
+    #end
+    #run_test('string_value') { |value| Assert.equals(value, 'string_value') }
+    #run_test({'key' => 'key_value'}) { |value| Assert.equals(value, {'key' => 'key_value'}) }
+    #run_test(%w(foo bar juu)) { |value| Assert.equals(value, %w(foo bar juu)) }
+
+
+#def testMethodWithGenericParam():
+    #obj.method_with_generic_param 'String', 'foo'
+    #obj.method_with_generic_param 'JsonObject', {'foo'=>'hello','bar'=>123}
+    #obj.method_with_generic_param 'JsonArray', ['foo', 'bar', 'wib']
+
+
+#def testMethodWithGenericHandler():
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler('String') { |val| Assert.equals(val.class, String); Assert.equals(val, 'foo'); dct['count'] += 1 }
+    #Assert.equals(1, count)
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler('Ref') { |val| Assert.equals(val.getString, 'bar'); dct['count'] += 1 }
+    #Assert.equals(1, count)
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler('JsonObject') { |val| Assert.equals(val.class, Hash); Assert.equals(val, {'foo'=>'hello','bar'=>123}); dct['count'] += 1 }
+    #Assert.equals(1, count)
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler('JsonArray') { |val| Assert.equals(val.class, Array); Assert.equals(val, ['foo','bar','wib']); dct['count'] += 1 }
+    #Assert.equals(1, count)
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler('JsonObjectComplex') { |val| Assert.equals(val.class, Hash); Assert.equals(val, {'outer' => {'foo' => 'hello'}, 'bar'=> ['this', 'that']}); dct['count'] += 1 }
+    #Assert.equals(1, count)
+
+
+#def testMethodWithGenericHandlerAsyncResult():
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler_async_result('String') { |err,val| Assert.is_nil(err); Assert.equals(val.class, String); Assert.equals(val, 'foo'); dct['count'] += 1 }
+    #Assert.equals(1, count)
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler_async_result('Ref') { |err,val| Assert.is_nil(err); Assert.equals(val.getString, 'bar'); dct['count'] += 1 }
+    #Assert.equals(1, count)
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler_async_result('JsonObject') { |err,val| Assert.is_nil(err); Assert.equals(val.class, Hash); Assert.equals(val, {'foo'=>'hello','bar'=>123}); dct['count'] += 1 }
+    #Assert.equals(1, count)
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler_async_result('JsonObjectComplex') { |err,val| Assert.is_nil(err); Assert.equals(val.class, Hash); Assert.equals(val, {'outer' => {'foo' => 'hello'}, 'bar'=> ['this', 'that']}); dct['count'] += 1 }
+    #Assert.equals(1, count)
+    #dct = dict(count=0)
+    #obj.method_with_generic_handler_async_result('JsonArray') { |err,val| Assert.is_nil(err); Assert.equals(val.class, Array); Assert.equals(val, ['foo','bar','wib']); dct['count'] += 1 }
+    #Assert.equals(1, count)
+
+
+#def testBasicReturns():
+    #ret = obj.method_with_byte_return
+    #Assert.equals(ret.class, Fixnum)
+    #Assert.equals(ret, 123)
+    #ret = obj.method_with_short_return
+    #Assert.equals(ret.class, Fixnum)
+    #Assert.equals(ret, 12345)
+    #ret = obj.method_with_int_return
+    #Assert.equals(ret.class, Fixnum)
+    #Assert.equals(ret, 12345464)
+    #ret = obj.method_with_long_return
+    #Assert.equals(ret.class, Fixnum)
+    #Assert.equals(ret, 65675123)
+    #ret = obj.method_with_float_return
+    #Assert.equals(ret.class, Float)
+    #Assert.equals(ret, 1.23)
+    #ret = obj.method_with_double_return
+    #Assert.equals(ret.class, Float)
+    #Assert.equals(ret, 3.34535)
+    #ret = obj.method_with_boolean_return?
+    #Assert.equals(ret.class, TrueClass)
+    #Assert.equals(ret, true)
+    #ret = obj.method_with_char_return
+    #Assert.equals(ret.class, Fixnum)
+    #Assert.equals(ret, 89)
+    #ret = obj.method_with_string_return
+    #Assert.equals(ret.class, String)
+    #Assert.equals(ret, 'orangutan')
+
+
+#def testVertxGenReturn():
+    #ret = obj.method_with_vertx_gen_return
+    #Assert.equals(ret.class, Testmodel::RefedInterface1)
+    #Assert.equals(ret.get_string, 'chaffinch')
+
+
+#def testVertxGenNullReturn():
+    #ret = obj.method_with_vertx_gen_null_return
+    #Assert.equals(nil, ret)
+
+
+#def testAbstractVertxGenReturn():
+    #ret = obj.method_with_abstract_vertx_gen_return
+    #Assert.equals(ret.is_a?(Testmodel::RefedInterface2), true)
+    #Assert.equals(ret.get_string, 'abstractchaffinch')
+
+
+#def testMapComplexJsonArrayReturn():
+    #map = obj.method_with_map_complex_json_array_return {}
+    #m = map['foo']
+    #Assert.equals m, [{'foo' => 'hello'}, {'bar' => 'bye'}]
+
+
+#def testOverloadedMethods():
+    #@refed_obj.set_string('dog')
+    #called = false
+    #ret = obj.overloaded_method('cat', @refed_obj)
+    #Assert.equals(ret, 'meth1')
+    #ret = obj.overloaded_method('cat', @refed_obj, 12345) { |animal| Assert.equals(animal, 'giraffe') ; called = true }
+    #Assert.equals(ret, 'meth2')
+    #Assert.equals(called, true)
+    #called = false
+    ## for some reason animal is sometimes equals to giraffe and sometimes empty
+    #ret = obj.overloaded_method('cat') { |animal| called = true }
+    #Assert.equals(ret, 'meth3')
+    #Assert.equals(called, true)
+    #called = false
+    #ret = obj.overloaded_method('cat', @refed_obj) { |animal| Assert.equals(animal, 'giraffe') ; called = true }
+    #Assert.equals(ret, 'meth4')
+    #Assert.equals(called, true)
+    #Assert.argument_error { obj.overloaded_method 'cat' }
+    #Assert.argument_error { obj.overloaded_method('cat', @refed_obj, 12345) }
+    #Assert.argument_error { obj.overloaded_method {} }
+
+
+#def testSuperInterfaces():
+    #obj.super_method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
+    #Assert.equals(obj.is_a?(Testmodel::SuperInterface1), true)
+    #obj.other_super_method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
+    #Assert.equals(obj.is_a?(Testmodel::SuperInterface2), true)
+
+
+#def testMethodWithGenericReturn():
+    #ret = obj.method_with_generic_return('JsonObject')
+    #Assert.equals(ret.class, Hash)
+    #Assert.equals(ret, {'foo'=>'hello','bar'=>123})
+    #ret = obj.method_with_generic_return('JsonArray')
+    #Assert.equals(ret.class, Array)
+    #Assert.equals(ret, %w(foo bar wib))
+
+
+#def testFluentMethod():
+    #ret = obj.fluent_method('bar')
+    #Assert.equals(ret, obj)
+
+
+#def testStaticFactoryMethod():
+    #ret = Testmodel::TestInterface.static_factory_method('bar')
+    #Assert.equals(ret.class, Testmodel::RefedInterface1)
+    #Assert.equals(ret.get_string, 'bar')
+
+
+#def testMethodWithCachedReturn():
+    #ret = obj.method_with_cached_return('bar')
+    #ret2 = obj.method_with_cached_return('bar')
+    #Assert.equals ret, ret2
+    #ret3 = obj.method_with_cached_return('bar')
+    #Assert.equals ret, ret3
+    #Assert.equals ret.get_string, 'bar'
+    #Assert.equals ret2.get_string, 'bar'
+    #Assert.equals ret3.get_string, 'bar'
+    #ret.set_string 'foo'
+    #Assert.equals ret2.get_string, 'foo'
+    #Assert.equals ret3.get_string, 'foo'
+
+
+#def testJsonReturns():
+    #ret = obj.method_with_json_object_return
+    #Assert.equals(ret, {'cheese'=>'stilton'})
+    #ret = obj.method_with_json_array_return
+    #Assert.equals(ret, %w(socks shoes))
+
+
+#def testNullJsonReturns():
+    #ret = obj.method_with_null_json_object_return
+    #Assert.is_nil(ret)
+    #ret = obj.method_with_null_json_array_return
+    #Assert.is_nil(ret)
+
+
+#def testComplexJsonReturns():
+    #ret = obj.method_with_complex_json_object_return
+    #Assert.equals ret, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}
+    #ret = obj.method_with_complex_json_array_return
+    #Assert.equals ret, [{'foo' => 'hello'}, {'bar' => 'bye'}]
+
+
+#def testJsonParams():
+    #obj.method_with_json_params({'cat' => 'lion', 'cheese' => 'cheddar'}, %w(house spider))
+
+
+#def testNullJsonParams():
+    #Assert.argument_error { obj.method_with_null_json_params(nil, nil) }
+
+
+#def testJsonHandlerParams():
+    #dct = dict(count=0)
+    #obj.method_with_handler_json(
+        #Proc.new { |val| Assert.equals(val, {'cheese'=>'stilton'}); dct['count'] += 1 }) do  |val|
+      #Assert.equals(val, %w(socks shoes)); dct['count'] += 1
+    #end
+    #Assert.equals(2, count)
+
+
+#def testNullJsonHandlerParams():
+    #dct = dict(count=0)
+    #obj.method_with_handler_null_json(
+        #Proc.new { |val| Assert.is_nil(val); dct['count'] += 1 }) do |val|
+      #Assert.is_nil(val); dct['count'] += 1
+    #end
+    #Assert.equals(2, count)
+
+
+#def testComplexJsonHandlerParams():
+    #dct = dict(count=0)
+    #obj.method_with_handler_complex_json(
+        #Proc.new { |val| Assert.equals(val, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}); dct['count'] += 1 }) do |val|
+      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
+      #dct['count'] += 1
+    #end
+    #Assert.equals(2, count)
+
+
+#def testJsonHandlerAsyncResultParams():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_json_object { |err,val| Assert.is_nil(err); Assert.equals(val, {'cheese'=>'stilton'}); dct['count'] += 1 }
+    #obj.method_with_handler_async_result_json_array { |err,val| Assert.is_nil(err); Assert.equals(val, ['socks','shoes']); dct['count'] += 1 }
+    #Assert.equals(2, count)
+
+
+#def testNullJsonHandlerAsyncResultParams():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_null_json_object { |err,val| Assert.is_nil(err); Assert.is_nil(val); dct['count'] += 1 }
+    #obj.method_with_handler_async_result_null_json_array { |err,val| Assert.is_nil(err); Assert.is_nil(val); dct['count'] += 1 }
+    #Assert.equals(2, count)
+
+
+#def testEnumParam():
+    #ret = obj.method_with_enum_param('sausages', :TIM)
+    #Assert.equals(ret, 'sausagesTIM')
+
+
+#def testEnumReturn():
+    #ret = obj.method_with_enum_return('JULIEN')
+    #Assert.equals(:JULIEN, ret)
+
+
+#def testMapReturn():
+    #readLog = []
+    #writeLog = []
+    #map = obj.method_with_map_return{ |op|
+      #if op =~ /put\([^,]+,[^\)]+\)/ || op =~ /remove\([^\)]+\)/ || op == 'clear()'
+        #writeLog.push op
+      #elsif op == 'size()' || op =~ /get\([^\)]+\)/ || op == 'entrySet()'
+        #readLog.push op
+      #else
+        #raise "unsupported #{op}"
+      #end
+    #}
+    #map['foo'] = 'bar'
+    #Assert.equals writeLog, ['put(foo,bar)']
+    #readLog.clear
+    #writeLog.clear
+    #Assert.equals map['foo'], 'bar'
+    #Assert.is_not_nil readLog.index('get(foo)')
+    #Assert.equals writeLog, []
+    #map['wibble'] = 'quux'
+    #readLog.clear
+    #writeLog.clear
+    #Assert.equals map.size, 2
+    #Assert.equals map['wibble'], 'quux'
+    #Assert.is_not_nil readLog.index('size()')
+    #Assert.equals writeLog, []
+    #readLog.clear
+    #writeLog.clear
+    #map.delete('wibble')
+    #Assert.equals writeLog, ['remove(wibble)']
+    #Assert.equals map.size, 1
+    #map['blah'] = '123'
+    #key_dct = dict(count=0)
+    #readLog.clear
+    #writeLog.clear
+    #map.each { |k,v|
+      #if key_count == 0
+        #Assert.equals k, 'foo'
+        #Assert.equals v, 'bar'
+        #key_dct['count'] += 1
+      #else
+        #Assert.equals k, 'blah'
+        #Assert.equals v, '123'
+      #end
+    #}
+    #Assert.is_not_nil readLog.index('entrySet()')
+    #Assert.equals writeLog, []
+    #readLog.clear
+    #writeLog.clear
+    #map.clear
+    #Assert.equals writeLog, ['clear()']
+
+
+#def testMapStringReturn():
+    #map = obj.method_with_map_string_return {}
+    #val = map['foo']
+    #Assert.equals val.class, String
+    #Assert.equals val, 'bar'
+    #map['juu'] = 'daa'
+    #Assert.equals map, {'foo'=>'bar','juu'=>'daa'}
+    #Assert.argument_error { map['wibble'] = 123 }
+    #Assert.equals map, {'foo'=>'bar','juu'=>'daa'}
+
+
+#def testMapJsonObjectReturn():
+    #map = obj.method_with_map_json_object_return {}
+    #json = map['foo']
+    #Assert.equals json.class, Hash
+    #Assert.equals json['wibble'], 'eek'
+    #map['bar'] = {'juu'=>'daa'}
+    #Assert.equals map, {'foo'=>{'wibble'=>'eek'},'bar'=>{'juu'=>'daa'}}
+    #Assert.argument_error { map['juu'] = 123 }
+    #Assert.equals map, {'foo'=>{'wibble'=>'eek'},'bar'=>{'juu'=>'daa'}}
+
+
+#def testMapComplexJsonObjectReturn():
+    #map = obj.method_with_map_complex_json_object_return {}
+    #m = map['foo']
+    #Assert.equals m, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}
+
+
+#def testMapJsonArrayReturn():
+    #map = obj.method_with_map_json_array_return {}
+    #arr = map['foo']
+    #Assert.equals arr.class, Array
+    #Assert.equals arr, ['wibble']
+    #map['bar'] = ['spidey']
+    #Assert.equals map, {'foo'=>['wibble'],'bar'=>['spidey']}
+    #Assert.argument_error { map['juu'] = 123 }
+    #Assert.equals map, {'foo'=>['wibble'],'bar'=>['spidey']}
+
+
+#def testMapLongReturn():
+    #map = obj.method_with_map_long_return {}
+    #num = map['foo']
+    #Assert.equals num.class, Fixnum
+    #Assert.equals num, 123
+    #map['bar'] = 321
+    #Assert.equals map, {'foo'=>123,'bar'=>321}
+    #Assert.argument_error { map['juu'] = 'something' }
+    #Assert.equals map, {'foo'=>123,'bar'=>321}
+
+
+#def testMapIntegerReturn():
+    #map = obj.method_with_map_integer_return {}
+    #num = map['foo']
+    #Assert.equals num.class, Fixnum
+    #Assert.equals num, 123
+    #map['bar'] = 321
+    #Assert.equals map, {'foo'=>123,'bar'=>321}
+    #Assert.argument_error { map['juu'] = 'something' }
+    #Assert.equals map, {'foo'=>123,'bar'=>321}
+
+
+#def testMapShortReturn():
+    #map = obj.method_with_map_short_return {}
+    #num = map['foo']
+    #Assert.equals num.class, Fixnum
+    #Assert.equals num, 123
+    #map['bar'] = 321
+    #Assert.equals map, {'foo'=>123,'bar'=>321}
+    #Assert.argument_error { map['juu'] = 'something' }
+    #Assert.equals map, {'foo'=>123,'bar'=>321}
+
+
+#def testMapByteReturn():
+    #map = obj.method_with_map_byte_return {}
+    #num = map['foo']
+    #Assert.equals num.class, Fixnum
+    #Assert.equals num, 123
+    #map['bar'] = 12
+    #Assert.equals map, {'foo'=>123,'bar'=>12}
+    #Assert.argument_error { map['juu'] = 'something' }
+    #Assert.equals map, {'foo'=>123,'bar'=>12}
+
+
+#def testMapCharacterReturn():
+    #map = obj.method_with_map_character_return {}
+    #num = map['foo']
+    #Assert.equals num.class, Fixnum
+    #Assert.equals num, 88
+    #map['bar'] = 89
+    #Assert.equals map, {'foo'=>88,'bar'=>89}
+    #Assert.argument_error { map['juu'] = 'something' }
+    #Assert.equals map, {'foo'=>88,'bar'=>89}
+
+
+#def testMapBooleanReturn():
+    #map = obj.method_with_map_boolean_return {}
+    #num = map['foo']
+    #Assert.equals num.class, TrueClass
+    #Assert.equals num, true
+    #map['bar'] = false
+    #Assert.equals map, {'foo'=>true,'bar'=>false}
+    #map['juu'] = 'something'
+    #map['daa'] = nil
+    #Assert.equals map, {'foo'=>true,'bar'=>false,'juu'=>true,'daa'=>false}
+
+
+#def testMapFloatReturn():
+    #map = obj.method_with_map_float_return {}
+    #num = map['foo']
+    #Assert.equals num.class, Float
+    #Assert.equals num, 0.123
+    #map['bar'] = 0.321
+    #Assert.equals map['foo'], 0.123
+    #Assert.equals map['bar'], 0.321
+    #Assert.equals map.keys.sort, %w(bar foo)
+    #Assert.argument_error { map['juu'] = 'something' }
+    #Assert.equals map['foo'], 0.123
+    #Assert.equals map['bar'], 0.321
+    #Assert.equals map.keys.sort, %w(bar foo)
+
+
+#def testMapDoubleReturn():
+    #map = obj.method_with_map_double_return {}
+    #num = map['foo']
+    #Assert.equals num.class, Float
+    #Assert.equals num, 0.123
+    #map['bar'] = 0.321
+    #Assert.equals map, {'foo'=>0.123,'bar'=>0.321}
+    #Assert.argument_error { map['juu'] = 'something' }
+    #Assert.equals map, {'foo'=>0.123,'bar'=>0.321}
+
+
+#def testMapNullReturn():
+    #map = obj.method_with_null_map_return
+    #Assert.is_nil map
+
+
+#def testListStringReturn():
+    #ret = obj.method_with_list_string_return
+    #Assert.has_class ret, Array
+    #Assert.equals ret, %w(foo bar wibble)
+
+
+#def testListLongReturn():
+    #ret = obj.method_with_list_long_return
+    #Assert.has_class ret, Array
+    #Assert.equals ret, [123,456]
+
+
+#def testListJsonObjectReturn():
+    #ret = obj.method_with_list_json_object_return
+    #Assert.has_class ret, Array
+    #Assert.equals ret, [{'foo'=>'bar'},{'blah'=>'eek'}]
+
+
+#def testListComplexJsonObjectReturn():
+    #ret = obj.method_with_list_complex_json_object_return
+    #Assert.has_class ret, Array
+    #Assert.equals ret, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}]
+
+
+#def testListJsonArrayReturn():
+    #ret = obj.method_with_list_json_array_return
+    #Assert.has_class ret, Array
+    #Assert.equals ret, [['foo'],['blah']]
+
+
+#def testListComplexJsonArrayReturn():
+    #ret = obj.method_with_list_complex_json_array_return
+    #Assert.has_class ret, Array
+    #Assert.equals ret, [[{'foo' => 'hello'}],[{'bar' => 'bye'}]]
+
+
+#def testListVertxGenReturn():
+    #ret = obj.method_with_list_vertx_gen_return
+    #Assert.has_class ret, Array
+    #Assert.has_class ret[0], Testmodel::RefedInterface1
+    #Assert.equals ret[0].get_string, 'foo'
+    #Assert.has_class ret[1], Testmodel::RefedInterface1
+    #Assert.equals ret[1].get_string, 'bar'
+
+
+#def testSetStringReturn():
+    #ret = obj.method_with_set_string_return
+    #Assert.has_class ret, Set
+    #Assert.equals ret, Set.new(%w(foo bar wibble))
+
+
+#def testSetLongReturn():
+    #ret = obj.method_with_set_long_return
+    #Assert.has_class ret, Set
+    #Assert.equals ret, Set.new([123,456])
+
+
+#def testSetJsonObjectReturn():
+    #ret = obj.method_with_set_json_object_return
+    #Assert.has_class ret, Set
+    #Assert.equals ret, Set.new([{'foo'=>'bar'},{'blah'=>'eek'}])
+
+
+#def testSetComplexJsonObjectReturn():
+    #ret = obj.method_with_set_complex_json_object_return
+    #Assert.has_class ret, Set
+    #Assert.equals ret, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set
+
+
+#def testSetJsonArrayReturn():
+    #ret = obj.method_with_set_json_array_return
+    #Assert.has_class ret, Set
+    #Assert.equals ret, Set.new([['foo'],['blah']])
+
+
+#def testSetComplexJsonArrayReturn():
+    #ret = obj.method_with_set_complex_json_array_return
+    #Assert.has_class ret, Set
+    #Assert.equals ret, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set
+
+
+#def testSetVertxGenReturn():
+    #ret = obj.method_with_set_vertx_gen_return
+    #Assert.has_class ret, Set
+    #ret.each { |elt| Assert.has_class(elt, Testmodel::RefedInterface1) }
+    #Assert.equals(ret.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
+
+
+#def testComplexJsonHandlerAsyncResultParams():
+    #dct = dict(count=0)
+    #obj.method_with_handler_async_result_complex_json_object { |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']})
+      #dct['count'] += 1
+    #}
+    #obj.method_with_handler_async_result_complex_json_array { |err,val|
+      #Assert.is_nil(err)
+      #Assert.equals(val, [{'foo' => 'hello'}, {'bar' => 'bye'}])
+      #dct['count'] += 1
+    #}
+    #Assert.equals(2, count)
+
+
+#def testThrowableReturn():
+    #ret = obj.method_with_throwable_return 'bogies'
+    #Assert.equals('bogies', ret.message)
+
+
+#def testCustomModule():
+    #my = Acme::MyInterface.create
+    #test_interface = my.method
+    #test_interface.method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
+    #sub = my.sub
+    #ret = sub.reverse "hello"
+    #Assert.equals ret, "olleh"
+
+
+#def testMethodWithListParams():
+    #obj.method_with_list_params(
+        #%w(foo bar),
+        #[2, 3],
+        #[12, 13],
+        #[1234, 1345],
+        #[123, 456],
+        #[{:foo=>'bar'}, {:eek=>'wibble'}],
+        #[['foo'], ['blah']],
+        #[Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'), Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')],
+        #[{:foo=>'String 1',:bar=>1,:wibble=>1.1}, {:foo=>'String 2',:bar=>2,:wibble=>2.2}]
+    #)
+    #Assert.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
+
+
+#def testMethodWithSetParams():
+    #obj.method_with_set_params(
+        #Set.new(['foo', 'bar']),
+        #Set.new([2, 3]),
+        #Set.new([12, 13]),
+        #Set.new([1234, 1345]),
+        #Set.new([123, 456]),
+        #Set.new([{:foo=>'bar'}, {:eek=>'wibble'}]),
+        #Set.new([['foo'], ['blah']]),
+        #Set.new([Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'), Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')]),
+        #Set.new([{:foo=>'String 1',:bar=>1,:wibble=>1.1}, {:foo=>'String 2',:bar=>2,:wibble=>2.2}])
+    #)
+    #Assert.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
+
+
+#def testMethodWithMapParams():
+    #obj.method_with_map_params(
+        #{'foo'=>'bar','eek'=>'wibble'},
+        #{'foo'=>2,'eek'=>3},
+        #{'foo'=>12,'eek'=>13},
+        #{'foo'=>1234,'eek'=>1345},
+        #{'foo'=>123,'eek'=>456},
+        #{'foo'=>{'foo'=>'bar'},'eek'=>{'eek'=>'wibble'}},
+        #{'foo'=>['foo'],'eek'=>['blah']},
+        #{'foo'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'),'eek'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')}
+    #)
+    #Assert.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
+
+
+if __name__ == "__main__":
+    meth = sys.argv[3]
+    print("calling {}".format(meth))
+    globals()[meth]()

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1158,11 +1158,10 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(ret.get_string(), 'abstractchaffinch')
 
 
-    #def testMapComplexJsonArrayReturn(self):
-        #def handler(map):
-            #m = map['foo']
-            #self.assertEqual(m, [{'foo' : 'hello'}, {'bar' : 'bye'}])
-        #obj.method_with_map_complex_json_array_return(handler)
+    def testMapComplexJsonArrayReturn(self):
+        out = obj.method_with_map_complex_json_array_return(lambda x: x)
+        m = out['foo']
+        self.assertEqual(m, [{'foo' : 'hello'}, {'bar' : 'bye'}])
 
 
     #def testOverloadedMethods(self):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -176,9 +176,10 @@ class TestAPI(unittest.TestCase):
         obj.method_with_data_object_param(**data_object)
 
 
-    def testNullDataObjectParam(self):
-        data_object = {}
-        obj.method_with_null_data_object_param(**data_object)
+    #TODO not really possible to pass a Null object w/ Python API
+    #def testNullDataObjectParam(self):
+        #data_object = {}
+        #obj.method_with_null_data_object_param(**data_object)
 
 
     def testMethodWithHandlerDataObject(self):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -92,7 +92,7 @@ def testMethodWithHandlerAsyncResultBasicTypes():
         dct['count'] += 1
     def long_handler(l, err):
         Assert.assertEquals(type(l), long)
-        Assert.assertEquals(1265615234l, l, 0)
+        Assert.assertEquals(1265615234, l, 0)
         Assert.assertNull(err)
         dct['count'] += 1
     def float_handler(f, err):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -180,9 +180,9 @@ class TestAPI(unittest.TestCase):
     def testMethodWithHandlerDataObject(self):
         dct = dict(count=0)
         def handler(option):
-            self.assertEqual("foo", option.foo)
-            self.assertEqual(123, option.bar)
-            self.assertEqual(0.0, option.wibble)
+            self.assertEqual("foo", option['foo'])
+            self.assertEqual(123, option['bar'])
+            self.assertEqual(0.0, option['wibble'])
             dct['count'] += 1
         obj.method_with_handler_data_object(handler)
         self.assertEqual(dct['count'], 1)
@@ -191,37 +191,86 @@ class TestAPI(unittest.TestCase):
     def testMethodWithHandlerAsyncResultDataObject(self):
         dct = dict(count=0)
         def handler(option, err):
-            self.assertIsNone(option);
-            self.assertIsNotNone(err);
-            self.assertEqual("foobar!", err.getMessage());
-            dct['count'] += 1;
+            self.assertIsNone(err)
+            self.assertEqual("foo", option['foo'])
+            self.assertEqual(123, option['bar'])
+            self.assertEqual(0.0, option['wibble'])
+            dct['count'] += 1
+        obj.method_with_handler_async_result_data_object(False, handler)
         self.assertEqual(dct['count'], 1)
 
 
-    #def testMethodWithHandlerAsyncResultDataObjectFails(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_data_object(true) { |err,val| self.is_nil(val); Assert.is_not_nil(err); Assert.equals(err.message, 'foobar!'); dct['count'] += 1 }
-        #self.equals(count, 1)
+    def testMethodWithHandlerAsyncResultDataObjectFails(self):
+        dct = dict(count=0)
+        def handler(option, err):
+            self.assertIsNone(option)
+            self.assertIsNotNone(err)
+            self.assertEqual("foobar!", err.getMessage())
+            dct['count'] += 1
+        obj.method_with_handler_async_result_data_object(True, handler)
+        self.assertEqual(dct['count'], 1)
 
 
-    #def testMethodWithHandlerListAndSet(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_and_set(
-            #Proc.new { |val| self.equals(val, %w(foo bar wibble)); dct['count'] += 1 },
-            #Proc.new { |val| self.equals(val, [5,12,100]); dct['count'] += 1 },
-            #Proc.new { |val| self.equals(val, Set.new(%w(foo bar wibble))); dct['count'] += 1 }) do |val|
-          #self.equals(val, Set.new([5,12,100])); dct['count'] += 1
-        #end
-        #self.equals(4, count)
+    def testMethodWithHandlerListAndSet(self):
+        dct = dict(count=0)
+        def handle_str_list(l):
+            self.assertEqual(l, list)
+            self.assertEqual("foo", l[0])
+            self.assertEqual("bar", l[1])
+            self.assertEqual("wibble", l[2])
+            dct['count'] += 1
+        def handle_int_list(l):
+            self.assertEqual(l, list)
+            self.assertEqual(5, l[0])
+            self.assertEqual(12, l[1])
+            self.assertEqual(100, l[2])
+            dct['count'] += 1
+        def handle_str_set(s):
+            self.assertEqual(s, set)
+            self.assertSetEqual(set(['foo', 'bar', 'wibble']), s)
+            dct['count'] += 1
+        def handle_int_set(s):
+            self.assertEqual(s, set)
+            self.assertSetEqual(set([5, 12, 100]), s)
+            dct['count'] += 1
+
+        obj.method_with_handler_list_and_set(handle_str_list, handle_int_list,
+                                             handle_str_set, handle_int_set)
+        self.assertEquals(dct['count'], 4)
 
 
-    #def testMethodWithHandlerAsyncResultListAndSet(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_string { |err,val| self.is_nil(err); Assert.equals(val, %w(foo bar wibble)); dct['count'] += 1 }
-        #obj.method_with_handler_async_result_list_integer { |err,val| self.is_nil(err); Assert.equals(val, [5,12,100]); dct['count'] += 1 }
-        #obj.method_with_handler_async_result_set_string { |err,val| self.is_nil(err); Assert.equals(val, Set.new(%w(foo bar wibble))); dct['count'] += 1 }
-        #obj.method_with_handler_async_result_set_integer { |err,val| self.is_nil(err); Assert.equals(val, Set.new([5,12,100])); dct['count'] += 1 }
-        #self.equals(4, count)
+    def testMethodWithHandlerAsyncResultListAndSet(self):
+        dct = dict(count=0)
+        def handle_str_list(l, err):
+            self.assertIsNone(err)
+            self.assertEqual(l, list)
+            self.assertEqual("foo", l[0])
+            self.assertEqual("bar", l[1])
+            self.assertEqual("wibble", l[2])
+            dct['count'] += 1
+        def handle_int_list(l, err):
+            self.assertIsNone(err)
+            self.assertEqual(l, list)
+            self.assertEqual(5, l[0])
+            self.assertEqual(12, l[1])
+            self.assertEqual(100, l[2])
+            dct['count'] += 1
+        def handle_str_set(s, err):
+            self.assertIsNone(err)
+            self.assertEqual(s, set)
+            self.assertSetEqual(set(['foo', 'bar', 'wibble']), s)
+            dct['count'] += 1
+        def handle_int_set(s, err):
+            self.assertIsNone(err)
+            self.assertEqual(s, set)
+            self.assertSetEqual(set([5, 12, 100]), s)
+            dct['count'] += 1
+
+        obj.method_with_handler_async_result_list_string(handle_str_list)
+        obj.method_with_handler_async_result_list_integer(handle_int_list)
+        obj.method_with_handler_async_result_set_string(handle_str_set)
+        obj.method_with_handler_async_result_set_integer(handle_int_set)
+        self.assertEquals(dct['count'], 4)
 
 
     #def testMethodWithHandlerListVertxGen(self):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1590,58 +1590,58 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(ret, "olleh")
 
 
-    def testMethodWithListParams(self):
-        obj.method_with_list_params(
-            ['foo', 'bar'],
-            [2, 3],
-            [12, 13],
-            [1234, 1345],
-            [123, 456],
-            [{'foo':'bar'}, {'eek':'wibble'}],
-            [['foo'], ['blah']],
-            [RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
-             RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')],
-            [{'foo':'String 1','bar':1,'wibble':1.1}, {'foo':'String 2','bar':2,'wibble':2.2}]
-        )
-        self.assertRaises(TypeError,
-                          obj.method_with_list_params(None, None, None, None, 
-                                                      None, None, None, None))
+    #def testMethodWithListParams(self):
+        #obj.method_with_list_params(
+            #['foo', 'bar'],
+            #[2, 3],
+            #[12, 13],
+            #[1234, 1345],
+            #[123, 456],
+            #[{'foo':'bar'}, {'eek':'wibble'}],
+            #[['foo'], ['blah']],
+            #[RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
+             #RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')],
+            #[{'foo':'String 1','bar':1,'wibble':1.1}, {'foo':'String 2','bar':2,'wibble':2.2}]
+        #)
+        #self.assertRaises(TypeError,
+                          #obj.method_with_list_params(None, None, None, None, 
+                                                      #None, None, None, None))
 
 
-    def testMethodWithSetParams(self):
-        obj.method_with_set_params(
-            set(['foo', 'bar']),
-            set([2, 3]),
-            set([12, 13]),
-            set([1234, 1345]),
-            set([123, 456]),
-            set([frozendict({'foo':'bar'}), frozendict({'eek':'wibble'})]),
-            set([frozenset(['foo']), frozenset(['blah'])]),
-            set([RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
-             RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')]),
-            set([frozendict({'foo':'String 1','bar':1,'wibble':1.1}), 
-                 frozendict({'foo':'String 2','bar':2,'wibble':2.2})])
-        )
-        self.assertRaises(TypeError,
-                          obj.method_with_set_params(None, None, None, None, 
-                                                     None, None, None, None))
+    #def testMethodWithSetParams(self):
+        #obj.method_with_set_params(
+            #set(['foo', 'bar']),
+            #set([2, 3]),
+            #set([12, 13]),
+            #set([1234, 1345]),
+            #set([123, 456]),
+            #set([frozendict({'foo':'bar'}), frozendict({'eek':'wibble'})]),
+            #set([frozenset(['foo']), frozenset(['blah'])]),
+            #set([RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
+             #RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')]),
+            #set([frozendict({'foo':'String 1','bar':1,'wibble':1.1}), 
+                 #frozendict({'foo':'String 2','bar':2,'wibble':2.2})])
+        #)
+        #self.assertRaises(TypeError,
+                          #obj.method_with_set_params(None, None, None, None, 
+                                                     #None, None, None, None))
 
 
-    def testMethodWithMapParams(self):
-        obj.method_with_map_params(
-            {'foo' : 'bar', 'eek' : 'wibble'},
-            {'foo' : 2, 'eek' : 3},
-            {'foo' : 12, 'eek' : 13},
-            {'foo' : 1234, 'eek' : 1345},
-            {'foo' : 123, 'eek' : 456},
-            {'foo' : {'foo' : 'bar'}, 'eek' : {'eek' : 'wibble'}},
-            {'foo' : ['foo'], 'eek' : ['blah']},
-            {'foo' : RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'),
-             'eek' : RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')}
-        )
-        self.assertRaises(TypeError,
-                          obj.method_with_map_params(None, None, None, None, 
-                                                     None, None, None, None))
+    #def testMethodWithMapParams(self):
+        #obj.method_with_map_params(
+            #{'foo' : 'bar', 'eek' : 'wibble'},
+            #{'foo' : 2, 'eek' : 3},
+            #{'foo' : 12, 'eek' : 13},
+            #{'foo' : 1234, 'eek' : 1345},
+            #{'foo' : 123, 'eek' : 456},
+            #{'foo' : {'foo' : 'bar'}, 'eek' : {'eek' : 'wibble'}},
+            #{'foo' : ['foo'], 'eek' : ['blah']},
+            #{'foo' : RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'),
+             #'eek' : RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')}
+        #)
+        #self.assertRaises(TypeError,
+                          #obj.method_with_map_params(None, None, None, None, 
+                                                     #None, None, None, None))
 
 
     def testEnumReturn(self):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -237,7 +237,7 @@ class TestAPI(unittest.TestCase):
 
         obj.method_with_handler_list_and_set(handle_str_list, handle_int_list,
                                              handle_str_set, handle_int_set)
-        self.assertEquals(dct['count'], 4)
+        self.assertEqual(dct['count'], 4)
 
 
     def testMethodWithHandlerAsyncResultListAndSet(self):
@@ -271,7 +271,7 @@ class TestAPI(unittest.TestCase):
         obj.method_with_handler_async_result_list_integer(handle_int_list)
         obj.method_with_handler_async_result_set_string(handle_str_set)
         obj.method_with_handler_async_result_set_integer(handle_int_set)
-        self.assertEquals(dct['count'], 4)
+        self.assertEqual(dct['count'], 4)
 
 
     def testMethodWithHandlerListVertxGen(self):
@@ -284,31 +284,31 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(type(val[1]), RefedInterface1)
             self.assertEqual(val[1].get_string(), 'bar')
             dct['count'] += 1
-        obj.method_with_handler_list_vertx_gen()
-        self.assertEquals(dct['count'], 1)
+        obj.method_with_handler_list_vertx_gen(handler)
+        self.assertEqual(dct['count'], 1)
 
     def testMethodWithHandlerUserTypes(self):
         dct = dict(count=0)
         def handler(val):
-            self.assertEquals(type(val), RefedInterface1)
-            self.assertEquals(val.get_string(), 'echidnas')
+            self.assertEqual(type(val), RefedInterface1)
+            self.assertEqual(val.get_string(), 'echidnas')
             dct['count'] += 1
-        obj.method_with_handler_user_types()
-        self.assertEquals(dct['count'], 1)
+        obj.method_with_handler_user_types(handler)
+        self.assertEqual(dct['count'], 1)
 
     def testMethodWithHandlerListAbstractVertxGen(self):
         dct = dict(count=0)
         def handler(val):
             self.assertEqual(type(val), list)
             self.assertEqual(len(val), 2)
-            self.assertisInstance(val[0], RefedInterface2)
+            self.assertIsInstance(val[0], RefedInterface2)
             self.assertEqual(val[0].get_string(), 'abstractfoo')
-            self.assertisInstance(val[1], RefedInterface2)
+            self.assertIsInstance(val[1], RefedInterface2)
             self.assertEqual(val[1].get_string(), 'abstractbar')
             dct['count'] += 1
 
-        obj.method_with_handler_list_abstract_vertx_gen()
-        self.assertEquals(dct['count'], 1)
+        obj.method_with_handler_list_abstract_vertx_gen(handler)
+        self.assertEqual(dct['count'], 1)
 
 
     def testMethodWithHandlerAsyncResultListVertxGen(self):
@@ -322,8 +322,8 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(type(val[1]), RefedInterface1)
             self.assertEqual(val[1].get_string(), 'bar')
             dct['count'] += 1
-        obj.method_with_handler_list_vertx_gen()
-        self.assertEquals(dct['count'], 1)
+        obj.method_with_handler_async_result_list_vertx_gen(handler)
+        self.assertEqual(dct['count'], 1)
 
 
     def testMethodWithHandlerAsyncResultListAbstractVertxGen(self):
@@ -332,14 +332,14 @@ class TestAPI(unittest.TestCase):
             self.assertIsNone(err)
             self.assertEqual(type(val), list)
             self.assertEqual(len(val), 2)
-            self.assertisInstance(val[0], RefedInterface2)
+            self.assertIsInstance(val[0], RefedInterface2)
             self.assertEqual(val[0].get_string(), 'abstractfoo')
-            self.assertisInstance(val[1], RefedInterface2)
+            self.assertIsInstance(val[1], RefedInterface2)
             self.assertEqual(val[1].get_string(), 'abstractbar')
             dct['count'] += 1
 
-        obj.method_with_handler_list_abstract_vertx_gen()
-        self.assertEquals(dct['count'], 1)
+        obj.method_with_handler_async_result_list_abstract_vertx_gen(handler)
+        self.assertEqual(dct['count'], 1)
 
 
     def testMethodWithHandlerSetVertxGen(self):
@@ -348,74 +348,78 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(type(val), set)
             self.assertEqual(len(val), 2)
             for item in val:
-                self.assertEqual(type(val), RefedInterface1)
-                self.assertSetEqual(val, set(['foo', 'bar']))
+                self.assertEqual(type(item), RefedInterface1)
+            self.assertSetEqual(val, set(['foo', 'bar']))
             dct['count'] += 1
-        obj.method_with_handler_list_vertx_gen()
-        self.assertEquals(dct['count'], 1)
+        obj.method_with_handler_list_vertx_gen(handler)
+        self.assertEqual(dct['count'], 1)
 
 
-    #def testMethodWithHandlerSetAbstractVertxGen(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_abstract_vertx_gen do |val|
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 2)
-          #val.each { |elt| self.equals(elt.is_a?(Testmodel::RefedInterface2), true) }
-          #self.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(abstractfoo abstractbar)))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerSetAbstractVertxGen(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 2)
+            for item in val:
+                self.assertIsInstance(item, RefedInterface2)
+            self.assertSetEqual(val, set(['abstractfoo', 'abstractbar']))
+            dct['count'] += 1
+
+        obj.method_with_handler_set_abstract_vertx_gen(handler)
+        self.assertEqual(dct['count'], 1)
 
 
-    #def testMethodWithHandlerAsyncResultSetVertxGen(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_vertx_gen do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 2)
-          #val.each { |elt| self.equals(elt.class, Testmodel::RefedInterface1) }
-          #self.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerAsyncResultSetVertxGen(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 2)
+            for item in val:
+                self.assertEqual(type(item), RefedInterface1)
+            self.assertSetEqual(set([x.get_string() for x in val]), set(['foo', 'bar']))
+            dct['count'] += 1
+
+        obj.method_with_handler_async_result_set_vertx_gen(handler)
+        self.assertEqual(dct['count'], 1)
 
 
-    #def testMethodWithHandlerAsyncResultSetAbstractVertxGen(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_abstract_vertx_gen do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 2)
-          #val.each { |elt| self.equals(elt.is_a?(Testmodel::RefedInterface2), true) }
-          #self.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(abstractfoo abstractbar)))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerAsyncResultSetAbstractVertxGen(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 2)
+            for item in val:
+                self.assertIsInstance(item, RefedInterface2)
+            self.assertSetEqual(set([x.get_string() for x in val]), set(['abstractfoo', 'abstractbar']))
+            dct['count'] += 1
+
+        obj.method_with_handler_async_result_set_abstract_vertx_gen(handler)
+        self.assertEqual(dct['count'], 1)
 
 
-    #def testMethodWithHandlerListJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_json_object do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 2)
-          #self.equals(val[0].class, Hash)
-          #self.equals(val[0], {'cheese' => 'stilton'})
-          #self.equals(val[1].class, Hash)
-          #self.equals(val[1], {'socks' => 'tartan'})
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerListJsonObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 2)
+            self.assertEqual(type(val[0]), dict)
+            self.assertEqual(val[0], dict(cheese='stilton'))
+            self.assertEqual(type(val[1]), dict)
+            self.assertEqual(val[1], dict(socks='tartan'))
+        obj.method_with_handler_list_json_object(handler)
+        self.assertEqual(dct['count'], 2)
 
 
-    #def testMethodWithHandlerListNullJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_null_json_object do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 1)
-          #self.equals(val[0], nil)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerListNullJsonObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 1)
+            self.assertIsNone(val[0])
+        obj.method_with_handler_list_null_json_object(handler)
+        self.assertEqual(dct['count'], 1)
 
 
     #def testMethodWithHandlerListComplexJsonObject(self):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1644,21 +1644,30 @@ class TestAPI(unittest.TestCase):
                                                      None, None, None, None))
 
 
-    #def testEnumReturn(self):
-        #ret = obj.method_with_enum_return('JULIEN')
-        #self.assertEqual(:JULIEN, ret)
+    def testEnumReturn(self):
+        ret = obj.method_with_enum_return('JULIEN')
+        self.assertEqual('JULIEN', ret)
 
 
-    #def testEnumParam(self):
-        #ret = obj.method_with_enum_param('sausages', :TIM)
-        #self.assertEqual(ret, 'sausagesTIM')
+    def testEnumParam(self):
+        ret = obj.method_with_enum_param('sausages', "TIM")
+        self.assertEqual(ret, 'sausagesTIM')
 
 
 if __name__ == "__main__":
     meth = sys.argv[-1]
+    err = False
     print("Testing {}".format(meth))
     with util.handle_java_error():
-        case = TestAPI(meth)
-        case.debug()
+        if meth == "testEverything":
+            out = unittest.main(exit=False, argv=[sys.argv[0]])
+            result = out.result
+            if result.failures or result.errors:
+                err = True
+        else:
+            case = TestAPI(meth)
+            case.debug()
         util.vertx_shutdown()
+        if err:
+            sys.exit(1)
 

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -4,6 +4,7 @@ import unittest
 
 from testmodel_python.testmodel.test_interface import TestInterface
 from testmodel_python.testmodel.refed_interface1 import RefedInterface1
+from testmodel_python.testmodel.refed_interface2 import RefedInterface2
 from testmodel_python.testmodel.factory import Factory
 from acme_python.pkg.my_interface import MyInterface
 from acme_python.sub.sub_interface import SubInterface
@@ -214,23 +215,23 @@ class TestAPI(unittest.TestCase):
     def testMethodWithHandlerListAndSet(self):
         dct = dict(count=0)
         def handle_str_list(l):
-            self.assertEqual(l, list)
+            self.assertEqual(type(l), list)
             self.assertEqual("foo", l[0])
             self.assertEqual("bar", l[1])
             self.assertEqual("wibble", l[2])
             dct['count'] += 1
         def handle_int_list(l):
-            self.assertEqual(l, list)
+            self.assertEqual(type(l), list)
             self.assertEqual(5, l[0])
             self.assertEqual(12, l[1])
             self.assertEqual(100, l[2])
             dct['count'] += 1
         def handle_str_set(s):
-            self.assertEqual(s, set)
+            self.assertEqual(type(s), set)
             self.assertSetEqual(set(['foo', 'bar', 'wibble']), s)
             dct['count'] += 1
         def handle_int_set(s):
-            self.assertEqual(s, set)
+            self.assertEqual(type(s), set)
             self.assertSetEqual(set([5, 12, 100]), s)
             dct['count'] += 1
 
@@ -243,26 +244,26 @@ class TestAPI(unittest.TestCase):
         dct = dict(count=0)
         def handle_str_list(l, err):
             self.assertIsNone(err)
-            self.assertEqual(l, list)
+            self.assertEqual(type(l), list)
             self.assertEqual("foo", l[0])
             self.assertEqual("bar", l[1])
             self.assertEqual("wibble", l[2])
             dct['count'] += 1
         def handle_int_list(l, err):
             self.assertIsNone(err)
-            self.assertEqual(l, list)
+            self.assertEqual(type(l), list)
             self.assertEqual(5, l[0])
             self.assertEqual(12, l[1])
             self.assertEqual(100, l[2])
             dct['count'] += 1
         def handle_str_set(s, err):
             self.assertIsNone(err)
-            self.assertEqual(s, set)
+            self.assertEqual(type(s), set)
             self.assertSetEqual(set(['foo', 'bar', 'wibble']), s)
             dct['count'] += 1
         def handle_int_set(s, err):
             self.assertIsNone(err)
-            self.assertEqual(s, set)
+            self.assertEqual(type(s), set)
             self.assertSetEqual(set([5, 12, 100]), s)
             dct['count'] += 1
 
@@ -273,74 +274,85 @@ class TestAPI(unittest.TestCase):
         self.assertEquals(dct['count'], 4)
 
 
-    #def testMethodWithHandlerListVertxGen(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_vertx_gen do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 2)
-          #self.equals(val[0].class, Testmodel::RefedInterface1)
-          #self.equals(val[0].get_string, 'foo')
-          #self.equals(val[1].class, Testmodel::RefedInterface1)
-          #self.equals(val[1].get_string, 'bar')
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerListVertxGen(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 2)
+            self.assertEqual(type(val[0]), RefedInterface1)
+            self.assertEqual(val[0].get_string(), 'foo')
+            self.assertEqual(type(val[1]), RefedInterface1)
+            self.assertEqual(val[1].get_string(), 'bar')
+            dct['count'] += 1
+        obj.method_with_handler_list_vertx_gen()
+        self.assertEquals(dct['count'], 1)
+
+    def testMethodWithHandlerUserTypes(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEquals(type(val), RefedInterface1)
+            self.assertEquals(val.get_string(), 'echidnas')
+            dct['count'] += 1
+        obj.method_with_handler_user_types()
+        self.assertEquals(dct['count'], 1)
+
+    def testMethodWithHandlerListAbstractVertxGen(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 2)
+            self.assertisInstance(val[0], RefedInterface2)
+            self.assertEqual(val[0].get_string(), 'abstractfoo')
+            self.assertisInstance(val[1], RefedInterface2)
+            self.assertEqual(val[1].get_string(), 'abstractbar')
+            dct['count'] += 1
+
+        obj.method_with_handler_list_abstract_vertx_gen()
+        self.assertEquals(dct['count'], 1)
 
 
-    #def testMethodWithHandlerListAbstractVertxGen(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_abstract_vertx_gen do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 2)
-          #self.equals(val[0].is_a?(Testmodel::RefedInterface2), true)
-          #self.equals(val[0].get_string, 'abstractfoo')
-          #self.equals(val[1].is_a?(Testmodel::RefedInterface2), true)
-          #self.equals(val[1].get_string, 'abstractbar')
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerAsyncResultListVertxGen(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 2)
+            self.assertEqual(type(val[0]), RefedInterface1)
+            self.assertEqual(val[0].get_string(), 'foo')
+            self.assertEqual(type(val[1]), RefedInterface1)
+            self.assertEqual(val[1].get_string(), 'bar')
+            dct['count'] += 1
+        obj.method_with_handler_list_vertx_gen()
+        self.assertEquals(dct['count'], 1)
 
 
-    #def testMethodWithHandlerAsyncResultListVertxGen(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_vertx_gen do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 2)
-          #self.equals(val[0].class, Testmodel::RefedInterface1)
-          #self.equals(val[0].get_string, 'foo')
-          #self.equals(val[1].class, Testmodel::RefedInterface1)
-          #self.equals(val[1].get_string, 'bar')
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerAsyncResultListAbstractVertxGen(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 2)
+            self.assertisInstance(val[0], RefedInterface2)
+            self.assertEqual(val[0].get_string(), 'abstractfoo')
+            self.assertisInstance(val[1], RefedInterface2)
+            self.assertEqual(val[1].get_string(), 'abstractbar')
+            dct['count'] += 1
+
+        obj.method_with_handler_list_abstract_vertx_gen()
+        self.assertEquals(dct['count'], 1)
 
 
-    #def testMethodWithHandlerAsyncResultListAbstractVertxGen(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_abstract_vertx_gen do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 2)
-          #self.equals(val[0].is_a?(Testmodel::RefedInterface2), true)
-          #self.equals(val[0].get_string, 'abstractfoo')
-          #self.equals(val[1].is_a?(Testmodel::RefedInterface2), true)
-          #self.equals(val[1].get_string, 'abstractbar')
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerSetVertxGen(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_vertx_gen do |val|
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 2)
-          #val.each { |elt| self.equals(elt.class, Testmodel::RefedInterface1) }
-          #self.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
+    def testMethodWithHandlerSetVertxGen(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 2)
+            for item in val:
+                self.assertEqual(type(val), RefedInterface1)
+                self.assertSetEqual(val, set(['foo', 'bar']))
+            dct['count'] += 1
+        obj.method_with_handler_list_vertx_gen()
+        self.assertEquals(dct['count'], 1)
 
 
     #def testMethodWithHandlerSetAbstractVertxGen(self):
@@ -744,16 +756,6 @@ class TestAPI(unittest.TestCase):
         #obj.method_with_handler_async_result_set_null_data_object do |err,val|
           #self.is_nil(err)
           #self.equals(val, Set.new([nil]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerUserTypes(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_user_types do |val|
-          #self.equals(val.class, Testmodel::RefedInterface1)
-          #self.equals(val.get_string, 'echidnas')
           #dct['count'] += 1
         #end
         #self.equals(1, count)

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1236,83 +1236,88 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(ret3.get_string(), 'foo')
 
 
-    #def testJsonReturns(self):
-        #ret = obj.method_with_json_object_return
-        #self.assertEqual(ret, {'cheese'=>'stilton'})
-        #ret = obj.method_with_json_array_return
-        #self.assertEqual(ret, %w(socks shoes))
+    def testJsonReturns(self):
+        ret = obj.method_with_json_object_return()
+        self.assertEqual(ret, {'cheese' : 'stilton'})
+        ret = obj.method_with_json_array_return()
+        self.assertEqual(ret, ['socks', 'shoes'])
 
 
-    #def testNullJsonReturns(self):
-        #ret = obj.method_with_null_json_object_return
-        #self.is_nil(ret)
-        #ret = obj.method_with_null_json_array_return
-        #self.is_nil(ret)
+    def testNullJsonReturns(self):
+        ret = obj.method_with_null_json_object_return()
+        self.assertIsNone(ret)
+        ret = obj.method_with_null_json_array_return()
+        self.assertIsNone(ret)
 
 
-    #def testComplexJsonReturns(self):
-        #ret = obj.method_with_complex_json_object_return
-        #self.equals ret, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}
-        #ret = obj.method_with_complex_json_array_return
-        #self.equals ret, [{'foo' => 'hello'}, {'bar' => 'bye'}]
+    def testComplexJsonReturns(self):
+        ret = obj.method_with_complex_json_object_return()
+        self.assertEqual(ret, {'outer' : {'socks' : 'tartan'}, 'list': ['yellow', 'blue']})
+        ret = obj.method_with_complex_json_array_return()
+        self.assertEqual(ret, [{'foo' : 'hello'}, {'bar' : 'bye'}])
 
 
-    #def testEnumReturn(self):
-        #ret = obj.method_with_enum_return('JULIEN')
-        #self.assertEqual(:JULIEN, ret)
-
-
-    #def testMapReturn(self):
-        #readLog = []
-        #writeLog = []
-        #map = obj.method_with_map_return{ |op|
-          #if op =~ /put\([^,]+,[^\)]+\)/ || op =~ /remove\([^\)]+\)/ || op == 'clear()'
-            #writeLog.push op
-          #elsif op == 'size()' || op =~ /get\([^\)]+\)/ || op == 'entrySet()'
-            #readLog.push op
-          #else
-            #raise "unsupported #{op}"
-          #end
-        #}
-        #map['foo'] = 'bar'
-        #self.equals writeLog, ['put(foo,bar)']
+    def testMapReturn(self):
+        readLog = []
+        writeLog = []
+        def handler(op):
+            import re
+            print("YO {}".format(op))
+            wpatt = '|'.join(['put\([^,]+,[^\)]+\)', 'remove\([^\)]+\)'])
+            rpatt = 'get\([^\)]+\)'
+            m = re.match(wpatt, op)
+            if m or op == 'clear()':
+                writeLog.append(op)
+            else:
+                m = re.match(rpatt, op)
+                if m or op in ('size()', 'entryset()'):
+                    readLog.append(op)
+                else:
+                    raise Exception("Unsupported: {}".format(op))
+        print("starting")
+        map = obj.method_with_map_return(handler)
+        print(type(map))
+        print(map)
+        print(type(map))
+        map['foo'] = 'bar'
+        self.assertEqual(writeLog, ['put(foo,bar)'])
         #readLog.clear
         #writeLog.clear
-        #self.equals map['foo'], 'bar'
+        #self.assertEqual(map['foo'], 'bar')
         #self.is_not_nil readLog.index('get(foo)')
-        #self.equals writeLog, []
+        #self.assertEqual(writeLog, [])
         #map['wibble'] = 'quux'
         #readLog.clear
         #writeLog.clear
-        #self.equals map.size, 2
-        #self.equals map['wibble'], 'quux'
+        #self.assertEqual(map.size, 2)
+        #self.assertEqual(map['wibble'], 'quux')
         #self.is_not_nil readLog.index('size()')
-        #self.equals writeLog, []
+        #self.assertEqual(writeLog, [])
         #readLog.clear
         #writeLog.clear
         #map.delete('wibble')
-        #self.equals writeLog, ['remove(wibble)']
-        #self.equals map.size, 1
+        #self.assertEqual(writeLog, ['remove(wibble)'])
+        #self.assertEqual(map.size, 1)
         #map['blah'] = '123'
         #key_dct = dict(count=0)
         #readLog.clear
         #writeLog.clear
         #map.each { |k,v|
           #if key_count == 0
-            #self.equals k, 'foo'
-            #self.equals v, 'bar'
+            #self.assertEqual(k, 'foo')
+            #self.assertEqual(v, 'bar')
             #key_dct['count'] += 1
           #else
-            #self.equals k, 'blah'
-            #self.equals v, '123'
+            #self.assertEqual(k, 'blah')
+            #self.assertEqual(v, '123')
           #end
         #}
         #self.is_not_nil readLog.index('entrySet()')
-        #self.equals writeLog, []
+        #self.assertEqual(writeLog, [])
         #readLog.clear
         #writeLog.clear
         #map.clear
-        #self.equals writeLog, ['clear()']
+        #self.assertEqual(writeLog, ['clear()'])
 
 
     #def testMapStringReturn(self):
@@ -1596,6 +1601,11 @@ class TestAPI(unittest.TestCase):
             #{'foo'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'),'eek'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')}
         #)
         #self.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
+
+
+    #def testEnumReturn(self):
+        #ret = obj.method_with_enum_return('JULIEN')
+        #self.assertEqual(:JULIEN, ret)
 
 
     #def testEnumParam(self):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1,4 +1,6 @@
+from __future__ import unicode_literals, print_function, absolute_import
 import sys
+import unittest
 
 from testmodel_python.testmodel.test_interface import TestInterface
 from testmodel_python.testmodel.refed_interface1 import RefedInterface1
@@ -12,1405 +14,1412 @@ util.vertx_init()
 
 with util.handle_java_error():
     jvm = util.jvm
-    Assert = jvm.org.junit.Assert;
     obj = TestInterface(jvm.io.vertx.codegen.testmodel.TestInterfaceImpl())
     refed_obj = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
     refed_obj2 = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
 
-def testMethodWithBasicParams():
-    obj.method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88, 'foobar')
-
-def testMethodWithBasicBoxedParams():
-    obj.method_with_basic_boxed_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88)
-
-def testMethodWithHandlerBasicTypes():
-    dct = dict(count=0)
-    def byte_handler(b):
-        Assert.assertEquals(type(b), int)
-        Assert.assertEquals(123, b, 0)
-        dct['count'] += 1
-    def short_handler(s):
-        Assert.assertEquals(type(s), int)
-        Assert.assertEquals(12345, s, 0)
-        dct['count'] += 1
-    def int_handler(i):
-        Assert.assertEquals(type(i), int)
-        Assert.assertEquals(1234567, i, 0)
-        dct['count'] += 1
-    def long_handler(l):
-        Assert.assertEquals(type(l), long)
-        Assert.assertEquals(1265615234, l, 0)
-        dct['count'] += 1
-    def float_handler(f):
-        Assert.assertEquals(type(f), float)
-        Assert.assertEquals(12.345, f, 0)
-        dct['count'] += 1
-    def double_handler(d):
-        Assert.assertEquals(type(d), float)
-        Assert.assertEquals(12.34566, d, 0)
-        dct['count'] += 1
-    def boolean_handler(b):
-        Assert.assertEquals(type(b), bool)
-        Assert.assertTrue(b)
-        dct['count'] += 1
-    def char_handler(c):
-        Assert.assertEquals(type(c), str)
-        Assert.assertEquals('X', c)
-        dct['count'] += 1
-    def string_handler(s):
-        Assert.assertEquals(type(s), str)
-        Assert.assertEquals('quux!', str)
-        dct['count'] += 1
-
-    obj.methodWithHandlerBasicTypes(byte_handler, short_handler, int_handler, long_handler,
-                                    float_handler, double_handler, boolean_handler, char_handler,
-                                    string_handler)
-    Assert.assertEquals(dct['count'], 9, 0)
-          
-def testMethodWithHandlerAsyncResultBasicTypes():
-    dct = dict(count=0)
-    def byte_handler(b, err):
-        Assert.assertEquals(type(b), int)
-        Assert.assertEquals(123, b, 0)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    def short_handler(s, err):
-        Assert.assertEquals(type(s), int)
-        Assert.assertEquals(12345, s, 0)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    def int_handler(i, err):
-        Assert.assertEquals(type(i), int)
-        Assert.assertEquals(1234567, i, 0)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    def long_handler(l, err):
-        Assert.assertEquals(type(l), long)
-        Assert.assertEquals(1265615234, l, 0)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    def float_handler(f, err):
-        Assert.assertEquals(type(f), float)
-        Assert.assertEquals(12.345, f, 0)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    def double_handler(d, err):
-        Assert.assertEquals(type(d), float)
-        Assert.assertEquals(12.34566, d, 0)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    def boolean_handler(b, err):
-        Assert.assertEquals(type(b), bool)
-        Assert.assertTrue(b)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    def char_handler(c, err):
-        Assert.assertEquals(type(c), str)
-        Assert.assertEquals('X', c)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    def string_handler(s, err):
-        Assert.assertEquals(type(s), str)
-        Assert.assertEquals('quux!', str)
-        Assert.assertNull(err)
-        dct['count'] += 1
-    obj.method_with_handler_async_result_byte(False, byte_handler)
-    obj.method_with_handler_async_result_short(False, byte_handler)
-    obj.method_with_handler_async_result_integer(False, byte_handler)
-    obj.method_with_handler_async_result_long(False, long_handler)
-    obj.method_with_handler_async_result_float(False, float_handler)
-    obj.method_with_handler_async_result_double(False, double_handler)
-    obj.method_with_handler_async_result_boolean(False, boolean_handler)
-    obj.method_with_handler_async_result_char(False, char_handler)
-    obj.method_with_handler_async_result_string(False, string_handler)
-    Assert.assertEquals(dct['count'], 9, 0)
-
-
-def testMethodWithHandlerAsyncResultBasicTypesFails():
-    dct = dict(count=0)
-    def handler(x, err):
-        Assert.assertNull(x);
-        Assert.assertNotNull(err);
-        Assert.assertEquals("foobar!", err.getMessage());
-        dct['count'] += 1
-
-    obj.method_with_handler_async_result_byte(True, handler)
-    obj.method_with_handler_async_result_short(True, handler)
-    obj.method_with_handler_async_result_integer(True, handler)
-    obj.method_with_handler_async_result_long(True, handler)
-    obj.method_with_handler_async_result_float(True, handler)
-    obj.method_with_handler_async_result_double(True, handler)
-    obj.method_with_handler_async_result_boolean(True, handler)
-    obj.method_with_handler_async_result_char(True, handler)
-    obj.method_with_handler_async_result_string(True, handler)
-    Assert.assertEquals(dct['count'], 9, 0)
-
-def testMethodWithUserTypes():
-    refed_obj.set_string('aardvarks')
-    obj.method_with_user_types(refed_obj)
-
-
-def testObjectParam():
-    obj.method_with_object_param('null', None)
-    obj.method_with_object_param('string', 'wibble')
-    obj.method_with_object_param('true', True)
-    obj.method_with_object_param('false', False)
-    obj.method_with_object_param('long', 123)
-    obj.method_with_object_param('double', 123.456)
-    json_obj = {"foo" : "hello", "bar" : 123}
-    obj.method_with_object_param('JsonObject', json_obj)
-    json_arr = ["foo", "bar", "wib"]
-    obj.method_with_object_param('JsonArray', json_arr)
-
-
-def testDataObjectParam():
-    data_object = {"foo" : "Hello", "bar" : 123, "wibble" : 1.23}
-    obj.method_with_data_object_param(data_object)
-
-
-def testNullDataObjectParam():
-    data_object = {}
-    obj.method_with_null_data_object_param(data_object)
-
-
-def testMethodWithHandlerDataObject():
-    dct = dict(count=0)
-    def handler(option):
-        Assert.assertEquals("foo", option.foo)
-        Assert.assertEquals(123, option.bar, 0)
-        Assert.assertEquals(0.0, option.wibble, 0)
-        dct['count'] += 1
-    obj.method_with_handler_data_object(handler)
-    Assert.assertEquals(dct['count'], 1, 0)
-
-
-#def testMethodWithHandlerAsyncResultDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_data_object(false) { |err,val| Assert.is_nil(err); Assert.equals(val, {'foo' => 'foo', 'bar' => 123, 'wibble' => 0.0}); dct['count'] += 1 }
-    #Assert.equals(count, 1)
-
-
-#def testMethodWithHandlerAsyncResultDataObjectFails():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_data_object(true) { |err,val| Assert.is_nil(val); Assert.is_not_nil(err); Assert.equals(err.message, 'foobar!'); dct['count'] += 1 }
-    #Assert.equals(count, 1)
-
-
-#def testMethodWithHandlerListAndSet():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_and_set(
-        #Proc.new { |val| Assert.equals(val, %w(foo bar wibble)); dct['count'] += 1 },
-        #Proc.new { |val| Assert.equals(val, [5,12,100]); dct['count'] += 1 },
-        #Proc.new { |val| Assert.equals(val, Set.new(%w(foo bar wibble))); dct['count'] += 1 }) do |val|
-      #Assert.equals(val, Set.new([5,12,100])); dct['count'] += 1
-    #end
-    #Assert.equals(4, count)
-
-
-#def testMethodWithHandlerAsyncResultListAndSet():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_string { |err,val| Assert.is_nil(err); Assert.equals(val, %w(foo bar wibble)); dct['count'] += 1 }
-    #obj.method_with_handler_async_result_list_integer { |err,val| Assert.is_nil(err); Assert.equals(val, [5,12,100]); dct['count'] += 1 }
-    #obj.method_with_handler_async_result_set_string { |err,val| Assert.is_nil(err); Assert.equals(val, Set.new(%w(foo bar wibble))); dct['count'] += 1 }
-    #obj.method_with_handler_async_result_set_integer { |err,val| Assert.is_nil(err); Assert.equals(val, Set.new([5,12,100])); dct['count'] += 1 }
-    #Assert.equals(4, count)
-
-
-#def testMethodWithHandlerListVertxGen():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_vertx_gen do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 2)
-      #Assert.equals(val[0].class, Testmodel::RefedInterface1)
-      #Assert.equals(val[0].get_string, 'foo')
-      #Assert.equals(val[1].class, Testmodel::RefedInterface1)
-      #Assert.equals(val[1].get_string, 'bar')
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListAbstractVertxGen():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_abstract_vertx_gen do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 2)
-      #Assert.equals(val[0].is_a?(Testmodel::RefedInterface2), true)
-      #Assert.equals(val[0].get_string, 'abstractfoo')
-      #Assert.equals(val[1].is_a?(Testmodel::RefedInterface2), true)
-      #Assert.equals(val[1].get_string, 'abstractbar')
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListVertxGen():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_vertx_gen do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 2)
-      #Assert.equals(val[0].class, Testmodel::RefedInterface1)
-      #Assert.equals(val[0].get_string, 'foo')
-      #Assert.equals(val[1].class, Testmodel::RefedInterface1)
-      #Assert.equals(val[1].get_string, 'bar')
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListAbstractVertxGen():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_abstract_vertx_gen do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 2)
-      #Assert.equals(val[0].is_a?(Testmodel::RefedInterface2), true)
-      #Assert.equals(val[0].get_string, 'abstractfoo')
-      #Assert.equals(val[1].is_a?(Testmodel::RefedInterface2), true)
-      #Assert.equals(val[1].get_string, 'abstractbar')
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetVertxGen():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_vertx_gen do |val|
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 2)
-      #val.each { |elt| Assert.equals(elt.class, Testmodel::RefedInterface1) }
-      #Assert.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetAbstractVertxGen():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_abstract_vertx_gen do |val|
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 2)
-      #val.each { |elt| Assert.equals(elt.is_a?(Testmodel::RefedInterface2), true) }
-      #Assert.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(abstractfoo abstractbar)))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetVertxGen():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_vertx_gen do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 2)
-      #val.each { |elt| Assert.equals(elt.class, Testmodel::RefedInterface1) }
-      #Assert.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetAbstractVertxGen():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_abstract_vertx_gen do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 2)
-      #val.each { |elt| Assert.equals(elt.is_a?(Testmodel::RefedInterface2), true) }
-      #Assert.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(abstractfoo abstractbar)))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_json_object do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 2)
-      #Assert.equals(val[0].class, Hash)
-      #Assert.equals(val[0], {'cheese' => 'stilton'})
-      #Assert.equals(val[1].class, Hash)
-      #Assert.equals(val[1], {'socks' => 'tartan'})
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListNullJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_null_json_object do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 1)
-      #Assert.equals(val[0], nil)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListComplexJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_complex_json_object do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 1)
-      #Assert.equals(val[0], {'outer' => {'socks' => 'tartan'}, 'list' => ['yellow', 'blue']})
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_json_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 2)
-      #Assert.equals(val[0].class, Hash)
-      #Assert.equals(val[0], {'cheese' => 'stilton'})
-      #Assert.equals(val[1].class, Hash)
-      #Assert.equals(val[1], {'socks' => 'tartan'})
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListNullJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_null_json_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 1)
-      #Assert.equals(val[0], nil)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListComplexJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_complex_json_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 1)
-      #Assert.equals(val[0], {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']})
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_json_object do |val|
-      #Assert.equals(val.class, Set)
-      #val.each { |elt| Assert.equals(elt.is_a?(Hash), true) }
-      #Assert.equals(val, Set.new([{'cheese' => 'stilton'},{'socks' => 'tartan'}]))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetNullJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_null_json_object do |val|
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 1)
-      #val.each { |elt| Assert.is_nil(elt) }
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetComplexJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_complex_json_object do |val|
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 1)
-      #Assert.equals(val, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_json_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Set)
-      #val.each { |elt| Assert.equals(elt.is_a?(Hash), true) }
-      #Assert.equals(val, Set.new([{'cheese' => 'stilton'},{'socks' => 'tartan'}]))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetNullJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_null_json_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 1)
-      #val.each { |elt| Assert.is_nil(elt) }
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetComplexJsonObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_complex_json_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 1)
-      #Assert.equals(val, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_json_array do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 2)
-      #Assert.equals(val[0].class, Array)
-      #Assert.equals(val[0], %w(green blue))
-      #Assert.equals(val[1].class, Array)
-      #Assert.equals(val[1], %w(yellow purple))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListNullJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_null_json_array do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 1)
-      #Assert.equals(val[0], nil)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_json_array do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 2)
-      #Assert.equals(val[0].class, Array)
-      #Assert.equals(val[0], %w(green blue))
-      #Assert.equals(val[1].class, Array)
-      #Assert.equals(val[1], %w(yellow purple))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListNullJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_null_json_array do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val.size, 1)
-      #Assert.equals(val[0], nil)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListComplexJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_complex_json_array do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_json_array do |val|
-      #Assert.equals(val.class, Set)
-      #val.each { |elt| Assert.equals(elt.is_a?(Array), true) }
-      #Assert.equals(val, Set.new([%w(green blue), %w(yellow purple)]))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetNullJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_null_json_array do |val|
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 1)
-      #val.each { |elt| Assert.is_nil(elt) }
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetComplexJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_complex_json_array do |val|
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_json_array do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Set)
-      #val.each { |elt| Assert.equals(elt.is_a?(Array), true) }
-      #Assert.equals(val, Set.new([%w(green blue), %w(yellow purple)]))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetNullJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_null_json_array do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val.size, 1)
-      #val.each { |elt| Assert.is_nil(elt) }
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListComplexJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_complex_json_array do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_data_object do |val|
-      #Assert.equals(val.class, Array)
-      #val.each { |elt| Assert.equals(elt.is_a?(Hash), true) }
-      #Assert.equals(val[0], {'foo'=>'String 1','bar'=>1,'wibble'=>1.1})
-      #Assert.equals(val[1], {'foo'=>'String 2','bar'=>2,'wibble'=>2.2})
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerListNullDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_list_null_data_object do |val|
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val[0], nil)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerSetDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_data_object do |val|
-      #Assert.equals(val, Set.new([{'foo'=>'String 1','bar'=>1,'wibble'=>1.1},{'foo'=>'String 2','bar'=>2,'wibble'=>2.2}]))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerNullSetDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_set_null_data_object do |val|
-      #Assert.equals(val, Set.new([nil]))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetComplexJsonArray():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_complex_json_array do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Set)
-      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_data_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #val.each { |elt| Assert.equals(elt.is_a?(Hash), true) }
-      #Assert.equals(val[0], {'foo'=>'String 1','bar'=>1,'wibble'=>1.1})
-      #Assert.equals(val[1], {'foo'=>'String 2','bar'=>2,'wibble'=>2.2})
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultListNullDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_list_null_data_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Array)
-      #Assert.equals(val[0], nil)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultSetDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_data_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val, Set.new([{'foo'=>'String 1','bar'=>1,'wibble'=>1.1},{'foo'=>'String 2','bar'=>2,'wibble'=>2.2}]))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultNullSetDataObject():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_set_null_data_object do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val, Set.new([nil]))
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerUserTypes():
-    #dct = dict(count=0)
-    #obj.method_with_handler_user_types do |val|
-      #Assert.equals(val.class, Testmodel::RefedInterface1)
-      #Assert.equals(val.get_string, 'echidnas')
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultUserTypes():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_user_types do |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val.class, Testmodel::RefedInterface1)
-      #Assert.equals(val.get_string, 'cheetahs')
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithConcreteHandlerUserTypeSubtype():
-    #dct = dict(count=0)
-    #arg = Testmodel::Factory.create_concrete_handler_user_type do |refedObj|
-      #Assert.equals(refedObj.class, Testmodel::RefedInterface1)
-      #Assert.equals(refedObj.get_string, 'echidnas')
-      #dct['count'] += 1
-    #end
-    #obj.method_with_concrete_handler_user_type_subtype arg
-    #Assert.equals(1, count)
-
-
-#def testMethodWithAbstractHandlerUserTypeSubtype():
-    #dct = dict(count=0)
-    #arg = Testmodel::Factory.create_abstract_handler_user_type do |refedObj|
-      #Assert.equals(refedObj.class, Testmodel::RefedInterface1)
-      #Assert.equals(refedObj.get_string, 'echidnas')
-      #dct['count'] += 1
-    #end
-    #obj.method_with_abstract_handler_user_type_subtype arg
-    #Assert.equals(1, count)
-
-
-#def testMethodWithConcreteHandlerUserTypeSubtypeExtension():
-    #dct = dict(count=0)
-    #arg = Testmodel::Factory.create_concrete_handler_user_type_extension do |refedObj|
-      #Assert.equals(refedObj.class, Testmodel::RefedInterface1)
-      #Assert.equals(refedObj.get_string, 'echidnas')
-      #dct['count'] += 1
-    #end
-    #obj.method_with_concrete_handler_user_type_subtype_extension arg
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerVoid():
-    #dct = dict(count=0)
-    #obj.method_with_handler_void do |val|
-      #Assert.is_nil(val)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultVoid():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_void(false) do |err|
-      #Assert.is_nil(err)
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerAsyncResultVoidFails():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_void(true) do |err|
-      #Assert.is_not_nil err
-      #Assert.equals(err.message, 'foo!')
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerThrowable():
-    #dct = dict(count=0)
-    #obj.method_with_handler_throwable do |err|
-      #Assert.is_not_nil err
-      #Assert.equals(err.message, 'cheese!')
-      #dct['count'] += 1
-    #end
-    #Assert.equals(1, count)
-
-
-#def testMethodWithHandlerGenericUserType():
-    #def run_test(value, &assert)():
-      #dct = dict(count=0)
-      #obj.method_with_handler_generic_user_type(value) do |refedObj|
-        #Assert.is_not_nil(refedObj)
-        #Assert.equals(refedObj.class, Testmodel::GenericRefedInterface)
-        #assert.call(refedObj.get_value)
-        #dct['count'] += 1
-      #end
-      #Assert.equals(1, count)
-    #end
-    #run_test('string_value') { |value| Assert.equals(value, 'string_value') }
-    #run_test({'key' => 'key_value'}) { |value| Assert.equals(value, {'key' => 'key_value'}) }
-    #run_test(%w(foo bar juu)) { |value| Assert.equals(value, %w(foo bar juu)) }
-
-
-#def testMethodWithHandlerAsyncResultGenericUserType():
-    #def run_test(value, &assert)():
-      #dct = dict(count=0)
-      #obj.method_with_handler_async_result_generic_user_type(value) do |err,refedObj|
-        #Assert.is_nil(err)
-        #Assert.is_not_nil(refedObj)
-        #Assert.equals(refedObj.class, Testmodel::GenericRefedInterface)
-        #assert.call(refedObj.get_value)
-        #dct['count'] += 1
-      #end
-      #Assert.equals(1, count)
-    #end
-    #run_test('string_value') { |value| Assert.equals(value, 'string_value') }
-    #run_test({'key' => 'key_value'}) { |value| Assert.equals(value, {'key' => 'key_value'}) }
-    #run_test(%w(foo bar juu)) { |value| Assert.equals(value, %w(foo bar juu)) }
-
-
-#def testMethodWithGenericParam():
-    #obj.method_with_generic_param 'String', 'foo'
-    #obj.method_with_generic_param 'JsonObject', {'foo'=>'hello','bar'=>123}
-    #obj.method_with_generic_param 'JsonArray', ['foo', 'bar', 'wib']
-
-
-#def testMethodWithGenericHandler():
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler('String') { |val| Assert.equals(val.class, String); Assert.equals(val, 'foo'); dct['count'] += 1 }
-    #Assert.equals(1, count)
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler('Ref') { |val| Assert.equals(val.getString, 'bar'); dct['count'] += 1 }
-    #Assert.equals(1, count)
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler('JsonObject') { |val| Assert.equals(val.class, Hash); Assert.equals(val, {'foo'=>'hello','bar'=>123}); dct['count'] += 1 }
-    #Assert.equals(1, count)
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler('JsonArray') { |val| Assert.equals(val.class, Array); Assert.equals(val, ['foo','bar','wib']); dct['count'] += 1 }
-    #Assert.equals(1, count)
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler('JsonObjectComplex') { |val| Assert.equals(val.class, Hash); Assert.equals(val, {'outer' => {'foo' => 'hello'}, 'bar'=> ['this', 'that']}); dct['count'] += 1 }
-    #Assert.equals(1, count)
-
-
-#def testMethodWithGenericHandlerAsyncResult():
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler_async_result('String') { |err,val| Assert.is_nil(err); Assert.equals(val.class, String); Assert.equals(val, 'foo'); dct['count'] += 1 }
-    #Assert.equals(1, count)
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler_async_result('Ref') { |err,val| Assert.is_nil(err); Assert.equals(val.getString, 'bar'); dct['count'] += 1 }
-    #Assert.equals(1, count)
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler_async_result('JsonObject') { |err,val| Assert.is_nil(err); Assert.equals(val.class, Hash); Assert.equals(val, {'foo'=>'hello','bar'=>123}); dct['count'] += 1 }
-    #Assert.equals(1, count)
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler_async_result('JsonObjectComplex') { |err,val| Assert.is_nil(err); Assert.equals(val.class, Hash); Assert.equals(val, {'outer' => {'foo' => 'hello'}, 'bar'=> ['this', 'that']}); dct['count'] += 1 }
-    #Assert.equals(1, count)
-    #dct = dict(count=0)
-    #obj.method_with_generic_handler_async_result('JsonArray') { |err,val| Assert.is_nil(err); Assert.equals(val.class, Array); Assert.equals(val, ['foo','bar','wib']); dct['count'] += 1 }
-    #Assert.equals(1, count)
-
-
-#def testBasicReturns():
-    #ret = obj.method_with_byte_return
-    #Assert.equals(ret.class, Fixnum)
-    #Assert.equals(ret, 123)
-    #ret = obj.method_with_short_return
-    #Assert.equals(ret.class, Fixnum)
-    #Assert.equals(ret, 12345)
-    #ret = obj.method_with_int_return
-    #Assert.equals(ret.class, Fixnum)
-    #Assert.equals(ret, 12345464)
-    #ret = obj.method_with_long_return
-    #Assert.equals(ret.class, Fixnum)
-    #Assert.equals(ret, 65675123)
-    #ret = obj.method_with_float_return
-    #Assert.equals(ret.class, Float)
-    #Assert.equals(ret, 1.23)
-    #ret = obj.method_with_double_return
-    #Assert.equals(ret.class, Float)
-    #Assert.equals(ret, 3.34535)
-    #ret = obj.method_with_boolean_return?
-    #Assert.equals(ret.class, TrueClass)
-    #Assert.equals(ret, true)
-    #ret = obj.method_with_char_return
-    #Assert.equals(ret.class, Fixnum)
-    #Assert.equals(ret, 89)
-    #ret = obj.method_with_string_return
-    #Assert.equals(ret.class, String)
-    #Assert.equals(ret, 'orangutan')
-
-
-#def testVertxGenReturn():
-    #ret = obj.method_with_vertx_gen_return
-    #Assert.equals(ret.class, Testmodel::RefedInterface1)
-    #Assert.equals(ret.get_string, 'chaffinch')
-
-
-#def testVertxGenNullReturn():
-    #ret = obj.method_with_vertx_gen_null_return
-    #Assert.equals(nil, ret)
-
-
-#def testAbstractVertxGenReturn():
-    #ret = obj.method_with_abstract_vertx_gen_return
-    #Assert.equals(ret.is_a?(Testmodel::RefedInterface2), true)
-    #Assert.equals(ret.get_string, 'abstractchaffinch')
-
-
-#def testMapComplexJsonArrayReturn():
-    #map = obj.method_with_map_complex_json_array_return {}
-    #m = map['foo']
-    #Assert.equals m, [{'foo' => 'hello'}, {'bar' => 'bye'}]
-
-
-#def testOverloadedMethods():
-    #@refed_obj.set_string('dog')
-    #called = false
-    #ret = obj.overloaded_method('cat', @refed_obj)
-    #Assert.equals(ret, 'meth1')
-    #ret = obj.overloaded_method('cat', @refed_obj, 12345) { |animal| Assert.equals(animal, 'giraffe') ; called = true }
-    #Assert.equals(ret, 'meth2')
-    #Assert.equals(called, true)
-    #called = false
-    ## for some reason animal is sometimes equals to giraffe and sometimes empty
-    #ret = obj.overloaded_method('cat') { |animal| called = true }
-    #Assert.equals(ret, 'meth3')
-    #Assert.equals(called, true)
-    #called = false
-    #ret = obj.overloaded_method('cat', @refed_obj) { |animal| Assert.equals(animal, 'giraffe') ; called = true }
-    #Assert.equals(ret, 'meth4')
-    #Assert.equals(called, true)
-    #Assert.argument_error { obj.overloaded_method 'cat' }
-    #Assert.argument_error { obj.overloaded_method('cat', @refed_obj, 12345) }
-    #Assert.argument_error { obj.overloaded_method {} }
-
-
-#def testSuperInterfaces():
-    #obj.super_method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
-    #Assert.equals(obj.is_a?(Testmodel::SuperInterface1), true)
-    #obj.other_super_method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
-    #Assert.equals(obj.is_a?(Testmodel::SuperInterface2), true)
-
-
-#def testMethodWithGenericReturn():
-    #ret = obj.method_with_generic_return('JsonObject')
-    #Assert.equals(ret.class, Hash)
-    #Assert.equals(ret, {'foo'=>'hello','bar'=>123})
-    #ret = obj.method_with_generic_return('JsonArray')
-    #Assert.equals(ret.class, Array)
-    #Assert.equals(ret, %w(foo bar wib))
-
-
-#def testFluentMethod():
-    #ret = obj.fluent_method('bar')
-    #Assert.equals(ret, obj)
-
-
-#def testStaticFactoryMethod():
-    #ret = Testmodel::TestInterface.static_factory_method('bar')
-    #Assert.equals(ret.class, Testmodel::RefedInterface1)
-    #Assert.equals(ret.get_string, 'bar')
-
-
-#def testMethodWithCachedReturn():
-    #ret = obj.method_with_cached_return('bar')
-    #ret2 = obj.method_with_cached_return('bar')
-    #Assert.equals ret, ret2
-    #ret3 = obj.method_with_cached_return('bar')
-    #Assert.equals ret, ret3
-    #Assert.equals ret.get_string, 'bar'
-    #Assert.equals ret2.get_string, 'bar'
-    #Assert.equals ret3.get_string, 'bar'
-    #ret.set_string 'foo'
-    #Assert.equals ret2.get_string, 'foo'
-    #Assert.equals ret3.get_string, 'foo'
-
-
-#def testJsonReturns():
-    #ret = obj.method_with_json_object_return
-    #Assert.equals(ret, {'cheese'=>'stilton'})
-    #ret = obj.method_with_json_array_return
-    #Assert.equals(ret, %w(socks shoes))
-
-
-#def testNullJsonReturns():
-    #ret = obj.method_with_null_json_object_return
-    #Assert.is_nil(ret)
-    #ret = obj.method_with_null_json_array_return
-    #Assert.is_nil(ret)
-
-
-#def testComplexJsonReturns():
-    #ret = obj.method_with_complex_json_object_return
-    #Assert.equals ret, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}
-    #ret = obj.method_with_complex_json_array_return
-    #Assert.equals ret, [{'foo' => 'hello'}, {'bar' => 'bye'}]
-
-
-#def testJsonParams():
-    #obj.method_with_json_params({'cat' => 'lion', 'cheese' => 'cheddar'}, %w(house spider))
-
-
-#def testNullJsonParams():
-    #Assert.argument_error { obj.method_with_null_json_params(nil, nil) }
-
-
-#def testJsonHandlerParams():
-    #dct = dict(count=0)
-    #obj.method_with_handler_json(
-        #Proc.new { |val| Assert.equals(val, {'cheese'=>'stilton'}); dct['count'] += 1 }) do  |val|
-      #Assert.equals(val, %w(socks shoes)); dct['count'] += 1
-    #end
-    #Assert.equals(2, count)
-
-
-#def testNullJsonHandlerParams():
-    #dct = dict(count=0)
-    #obj.method_with_handler_null_json(
-        #Proc.new { |val| Assert.is_nil(val); dct['count'] += 1 }) do |val|
-      #Assert.is_nil(val); dct['count'] += 1
-    #end
-    #Assert.equals(2, count)
-
-
-#def testComplexJsonHandlerParams():
-    #dct = dict(count=0)
-    #obj.method_with_handler_complex_json(
-        #Proc.new { |val| Assert.equals(val, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}); dct['count'] += 1 }) do |val|
-      #Assert.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
-      #dct['count'] += 1
-    #end
-    #Assert.equals(2, count)
-
-
-#def testJsonHandlerAsyncResultParams():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_json_object { |err,val| Assert.is_nil(err); Assert.equals(val, {'cheese'=>'stilton'}); dct['count'] += 1 }
-    #obj.method_with_handler_async_result_json_array { |err,val| Assert.is_nil(err); Assert.equals(val, ['socks','shoes']); dct['count'] += 1 }
-    #Assert.equals(2, count)
-
-
-#def testNullJsonHandlerAsyncResultParams():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_null_json_object { |err,val| Assert.is_nil(err); Assert.is_nil(val); dct['count'] += 1 }
-    #obj.method_with_handler_async_result_null_json_array { |err,val| Assert.is_nil(err); Assert.is_nil(val); dct['count'] += 1 }
-    #Assert.equals(2, count)
-
-
-#def testEnumParam():
-    #ret = obj.method_with_enum_param('sausages', :TIM)
-    #Assert.equals(ret, 'sausagesTIM')
-
-
-#def testEnumReturn():
-    #ret = obj.method_with_enum_return('JULIEN')
-    #Assert.equals(:JULIEN, ret)
-
-
-#def testMapReturn():
-    #readLog = []
-    #writeLog = []
-    #map = obj.method_with_map_return{ |op|
-      #if op =~ /put\([^,]+,[^\)]+\)/ || op =~ /remove\([^\)]+\)/ || op == 'clear()'
-        #writeLog.push op
-      #elsif op == 'size()' || op =~ /get\([^\)]+\)/ || op == 'entrySet()'
-        #readLog.push op
-      #else
-        #raise "unsupported #{op}"
-      #end
-    #}
-    #map['foo'] = 'bar'
-    #Assert.equals writeLog, ['put(foo,bar)']
-    #readLog.clear
-    #writeLog.clear
-    #Assert.equals map['foo'], 'bar'
-    #Assert.is_not_nil readLog.index('get(foo)')
-    #Assert.equals writeLog, []
-    #map['wibble'] = 'quux'
-    #readLog.clear
-    #writeLog.clear
-    #Assert.equals map.size, 2
-    #Assert.equals map['wibble'], 'quux'
-    #Assert.is_not_nil readLog.index('size()')
-    #Assert.equals writeLog, []
-    #readLog.clear
-    #writeLog.clear
-    #map.delete('wibble')
-    #Assert.equals writeLog, ['remove(wibble)']
-    #Assert.equals map.size, 1
-    #map['blah'] = '123'
-    #key_dct = dict(count=0)
-    #readLog.clear
-    #writeLog.clear
-    #map.each { |k,v|
-      #if key_count == 0
-        #Assert.equals k, 'foo'
-        #Assert.equals v, 'bar'
-        #key_dct['count'] += 1
-      #else
-        #Assert.equals k, 'blah'
-        #Assert.equals v, '123'
-      #end
-    #}
-    #Assert.is_not_nil readLog.index('entrySet()')
-    #Assert.equals writeLog, []
-    #readLog.clear
-    #writeLog.clear
-    #map.clear
-    #Assert.equals writeLog, ['clear()']
-
-
-#def testMapStringReturn():
-    #map = obj.method_with_map_string_return {}
-    #val = map['foo']
-    #Assert.equals val.class, String
-    #Assert.equals val, 'bar'
-    #map['juu'] = 'daa'
-    #Assert.equals map, {'foo'=>'bar','juu'=>'daa'}
-    #Assert.argument_error { map['wibble'] = 123 }
-    #Assert.equals map, {'foo'=>'bar','juu'=>'daa'}
-
-
-#def testMapJsonObjectReturn():
-    #map = obj.method_with_map_json_object_return {}
-    #json = map['foo']
-    #Assert.equals json.class, Hash
-    #Assert.equals json['wibble'], 'eek'
-    #map['bar'] = {'juu'=>'daa'}
-    #Assert.equals map, {'foo'=>{'wibble'=>'eek'},'bar'=>{'juu'=>'daa'}}
-    #Assert.argument_error { map['juu'] = 123 }
-    #Assert.equals map, {'foo'=>{'wibble'=>'eek'},'bar'=>{'juu'=>'daa'}}
-
-
-#def testMapComplexJsonObjectReturn():
-    #map = obj.method_with_map_complex_json_object_return {}
-    #m = map['foo']
-    #Assert.equals m, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}
-
-
-#def testMapJsonArrayReturn():
-    #map = obj.method_with_map_json_array_return {}
-    #arr = map['foo']
-    #Assert.equals arr.class, Array
-    #Assert.equals arr, ['wibble']
-    #map['bar'] = ['spidey']
-    #Assert.equals map, {'foo'=>['wibble'],'bar'=>['spidey']}
-    #Assert.argument_error { map['juu'] = 123 }
-    #Assert.equals map, {'foo'=>['wibble'],'bar'=>['spidey']}
-
-
-#def testMapLongReturn():
-    #map = obj.method_with_map_long_return {}
-    #num = map['foo']
-    #Assert.equals num.class, Fixnum
-    #Assert.equals num, 123
-    #map['bar'] = 321
-    #Assert.equals map, {'foo'=>123,'bar'=>321}
-    #Assert.argument_error { map['juu'] = 'something' }
-    #Assert.equals map, {'foo'=>123,'bar'=>321}
-
-
-#def testMapIntegerReturn():
-    #map = obj.method_with_map_integer_return {}
-    #num = map['foo']
-    #Assert.equals num.class, Fixnum
-    #Assert.equals num, 123
-    #map['bar'] = 321
-    #Assert.equals map, {'foo'=>123,'bar'=>321}
-    #Assert.argument_error { map['juu'] = 'something' }
-    #Assert.equals map, {'foo'=>123,'bar'=>321}
-
-
-#def testMapShortReturn():
-    #map = obj.method_with_map_short_return {}
-    #num = map['foo']
-    #Assert.equals num.class, Fixnum
-    #Assert.equals num, 123
-    #map['bar'] = 321
-    #Assert.equals map, {'foo'=>123,'bar'=>321}
-    #Assert.argument_error { map['juu'] = 'something' }
-    #Assert.equals map, {'foo'=>123,'bar'=>321}
-
-
-#def testMapByteReturn():
-    #map = obj.method_with_map_byte_return {}
-    #num = map['foo']
-    #Assert.equals num.class, Fixnum
-    #Assert.equals num, 123
-    #map['bar'] = 12
-    #Assert.equals map, {'foo'=>123,'bar'=>12}
-    #Assert.argument_error { map['juu'] = 'something' }
-    #Assert.equals map, {'foo'=>123,'bar'=>12}
-
-
-#def testMapCharacterReturn():
-    #map = obj.method_with_map_character_return {}
-    #num = map['foo']
-    #Assert.equals num.class, Fixnum
-    #Assert.equals num, 88
-    #map['bar'] = 89
-    #Assert.equals map, {'foo'=>88,'bar'=>89}
-    #Assert.argument_error { map['juu'] = 'something' }
-    #Assert.equals map, {'foo'=>88,'bar'=>89}
-
-
-#def testMapBooleanReturn():
-    #map = obj.method_with_map_boolean_return {}
-    #num = map['foo']
-    #Assert.equals num.class, TrueClass
-    #Assert.equals num, true
-    #map['bar'] = false
-    #Assert.equals map, {'foo'=>true,'bar'=>false}
-    #map['juu'] = 'something'
-    #map['daa'] = nil
-    #Assert.equals map, {'foo'=>true,'bar'=>false,'juu'=>true,'daa'=>false}
-
-
-#def testMapFloatReturn():
-    #map = obj.method_with_map_float_return {}
-    #num = map['foo']
-    #Assert.equals num.class, Float
-    #Assert.equals num, 0.123
-    #map['bar'] = 0.321
-    #Assert.equals map['foo'], 0.123
-    #Assert.equals map['bar'], 0.321
-    #Assert.equals map.keys.sort, %w(bar foo)
-    #Assert.argument_error { map['juu'] = 'something' }
-    #Assert.equals map['foo'], 0.123
-    #Assert.equals map['bar'], 0.321
-    #Assert.equals map.keys.sort, %w(bar foo)
-
-
-#def testMapDoubleReturn():
-    #map = obj.method_with_map_double_return {}
-    #num = map['foo']
-    #Assert.equals num.class, Float
-    #Assert.equals num, 0.123
-    #map['bar'] = 0.321
-    #Assert.equals map, {'foo'=>0.123,'bar'=>0.321}
-    #Assert.argument_error { map['juu'] = 'something' }
-    #Assert.equals map, {'foo'=>0.123,'bar'=>0.321}
-
-
-#def testMapNullReturn():
-    #map = obj.method_with_null_map_return
-    #Assert.is_nil map
-
-
-#def testListStringReturn():
-    #ret = obj.method_with_list_string_return
-    #Assert.has_class ret, Array
-    #Assert.equals ret, %w(foo bar wibble)
-
-
-#def testListLongReturn():
-    #ret = obj.method_with_list_long_return
-    #Assert.has_class ret, Array
-    #Assert.equals ret, [123,456]
-
-
-#def testListJsonObjectReturn():
-    #ret = obj.method_with_list_json_object_return
-    #Assert.has_class ret, Array
-    #Assert.equals ret, [{'foo'=>'bar'},{'blah'=>'eek'}]
-
-
-#def testListComplexJsonObjectReturn():
-    #ret = obj.method_with_list_complex_json_object_return
-    #Assert.has_class ret, Array
-    #Assert.equals ret, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}]
-
-
-#def testListJsonArrayReturn():
-    #ret = obj.method_with_list_json_array_return
-    #Assert.has_class ret, Array
-    #Assert.equals ret, [['foo'],['blah']]
-
-
-#def testListComplexJsonArrayReturn():
-    #ret = obj.method_with_list_complex_json_array_return
-    #Assert.has_class ret, Array
-    #Assert.equals ret, [[{'foo' => 'hello'}],[{'bar' => 'bye'}]]
-
-
-#def testListVertxGenReturn():
-    #ret = obj.method_with_list_vertx_gen_return
-    #Assert.has_class ret, Array
-    #Assert.has_class ret[0], Testmodel::RefedInterface1
-    #Assert.equals ret[0].get_string, 'foo'
-    #Assert.has_class ret[1], Testmodel::RefedInterface1
-    #Assert.equals ret[1].get_string, 'bar'
-
-
-#def testSetStringReturn():
-    #ret = obj.method_with_set_string_return
-    #Assert.has_class ret, Set
-    #Assert.equals ret, Set.new(%w(foo bar wibble))
-
-
-#def testSetLongReturn():
-    #ret = obj.method_with_set_long_return
-    #Assert.has_class ret, Set
-    #Assert.equals ret, Set.new([123,456])
-
-
-#def testSetJsonObjectReturn():
-    #ret = obj.method_with_set_json_object_return
-    #Assert.has_class ret, Set
-    #Assert.equals ret, Set.new([{'foo'=>'bar'},{'blah'=>'eek'}])
-
-
-#def testSetComplexJsonObjectReturn():
-    #ret = obj.method_with_set_complex_json_object_return
-    #Assert.has_class ret, Set
-    #Assert.equals ret, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set
-
-
-#def testSetJsonArrayReturn():
-    #ret = obj.method_with_set_json_array_return
-    #Assert.has_class ret, Set
-    #Assert.equals ret, Set.new([['foo'],['blah']])
-
-
-#def testSetComplexJsonArrayReturn():
-    #ret = obj.method_with_set_complex_json_array_return
-    #Assert.has_class ret, Set
-    #Assert.equals ret, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set
-
-
-#def testSetVertxGenReturn():
-    #ret = obj.method_with_set_vertx_gen_return
-    #Assert.has_class ret, Set
-    #ret.each { |elt| Assert.has_class(elt, Testmodel::RefedInterface1) }
-    #Assert.equals(ret.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
-
-
-#def testComplexJsonHandlerAsyncResultParams():
-    #dct = dict(count=0)
-    #obj.method_with_handler_async_result_complex_json_object { |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']})
-      #dct['count'] += 1
-    #}
-    #obj.method_with_handler_async_result_complex_json_array { |err,val|
-      #Assert.is_nil(err)
-      #Assert.equals(val, [{'foo' => 'hello'}, {'bar' => 'bye'}])
-      #dct['count'] += 1
-    #}
-    #Assert.equals(2, count)
-
-
-#def testThrowableReturn():
-    #ret = obj.method_with_throwable_return 'bogies'
-    #Assert.equals('bogies', ret.message)
-
-
-#def testCustomModule():
-    #my = Acme::MyInterface.create
-    #test_interface = my.method
-    #test_interface.method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
-    #sub = my.sub
-    #ret = sub.reverse "hello"
-    #Assert.equals ret, "olleh"
-
-
-#def testMethodWithListParams():
-    #obj.method_with_list_params(
-        #%w(foo bar),
-        #[2, 3],
-        #[12, 13],
-        #[1234, 1345],
-        #[123, 456],
-        #[{:foo=>'bar'}, {:eek=>'wibble'}],
-        #[['foo'], ['blah']],
-        #[Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'), Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')],
-        #[{:foo=>'String 1',:bar=>1,:wibble=>1.1}, {:foo=>'String 2',:bar=>2,:wibble=>2.2}]
-    #)
-    #Assert.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
-
-
-#def testMethodWithSetParams():
-    #obj.method_with_set_params(
-        #Set.new(['foo', 'bar']),
-        #Set.new([2, 3]),
-        #Set.new([12, 13]),
-        #Set.new([1234, 1345]),
-        #Set.new([123, 456]),
-        #Set.new([{:foo=>'bar'}, {:eek=>'wibble'}]),
-        #Set.new([['foo'], ['blah']]),
-        #Set.new([Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'), Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')]),
-        #Set.new([{:foo=>'String 1',:bar=>1,:wibble=>1.1}, {:foo=>'String 2',:bar=>2,:wibble=>2.2}])
-    #)
-    #Assert.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
-
-
-#def testMethodWithMapParams():
-    #obj.method_with_map_params(
-        #{'foo'=>'bar','eek'=>'wibble'},
-        #{'foo'=>2,'eek'=>3},
-        #{'foo'=>12,'eek'=>13},
-        #{'foo'=>1234,'eek'=>1345},
-        #{'foo'=>123,'eek'=>456},
-        #{'foo'=>{'foo'=>'bar'},'eek'=>{'eek'=>'wibble'}},
-        #{'foo'=>['foo'],'eek'=>['blah']},
-        #{'foo'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'),'eek'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')}
-    #)
-    #Assert.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
+class TestAPI(unittest.TestCase):
+    def testMethodWithBasicParams(self):
+        obj.method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88, 'foobar')
+
+    def testMethodWithBasicBoxedParams(self):
+        obj.method_with_basic_boxed_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88)
+
+    def testMethodWithHandlerBasicTypes(self):
+        dct = dict(count=0)
+        def byte_handler(b):
+            self.assertEqual(type(b), int)
+            self.assertEqual(123, b)
+            dct['count'] += 1
+        def short_handler(s):
+            self.assertEqual(type(s), int)
+            self.assertEqual(12345, s)
+            dct['count'] += 1
+        def int_handler(i):
+            self.assertEqual(type(i), int)
+            self.assertEqual(1234567, i)
+            dct['count'] += 1
+        def long_handler(l):
+            self.assertEqual(type(l), long)
+            self.assertEqual(1265615234, l)
+            dct['count'] += 1
+        def float_handler(f):
+            self.assertEqual(type(f), float)
+            self.assertEqual(12.345, f)
+            dct['count'] += 1
+        def double_handler(d):
+            self.assertEqual(type(d), float)
+            self.assertEqual(12.34566, d)
+            dct['count'] += 1
+        def boolean_handler(b):
+            self.assertEqual(type(b), bool)
+            self.assertTrue(b)
+            dct['count'] += 1
+        def char_handler(c):
+            self.assertEqual(type(c), unicode)
+            self.assertEqual('X', c)
+            dct['count'] += 1
+        def string_handler(s):
+            self.assertEqual(type(s), unicode)
+            self.assertEqual('quux!', s)
+            dct['count'] += 1
+
+        obj.method_with_handler_basic_types(byte_handler, short_handler, 
+                                            int_handler, long_handler,
+                                            float_handler, double_handler, 
+                                            boolean_handler, char_handler,
+                                            string_handler)
+        self.assertEqual(dct['count'], 9)
+              
+    def testMethodWithHandlerAsyncResultBasicTypes(self):
+        dct = dict(count=0)
+        def byte_handler(b, err):
+            self.assertEqual(type(b), int)
+            self.assertEqual(123, b)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def short_handler(s, err):
+            self.assertEqual(type(s), int)
+            self.assertEqual(12345, s)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def int_handler(i, err):
+            self.assertEqual(type(i), int)
+            self.assertEqual(1234567, i)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def long_handler(l, err):
+            self.assertEqual(type(l), long)
+            self.assertEqual(1265615234, l)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def float_handler(f, err):
+            self.assertEqual(type(f), float)
+            self.assertEqual(12.345, f)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def double_handler(d, err):
+            self.assertEqual(type(d), float)
+            self.assertEqual(12.34566, d)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def boolean_handler(b, err):
+            self.assertEqual(type(b), bool)
+            self.assertTrue(b)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def char_handler(c, err):
+            self.assertEqual(type(c), str)
+            self.assertEqual('X', c)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def string_handler(s, err):
+            self.assertEqual(type(s), str)
+            self.assertEqual('quux!', str)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        obj.method_with_handler_async_result_byte(False, byte_handler)
+        obj.method_with_handler_async_result_short(False, short_handler)
+        obj.method_with_handler_async_result_integer(False, int_handler)
+        obj.method_with_handler_async_result_long(False, long_handler)
+        obj.method_with_handler_async_result_float(False, float_handler)
+        obj.method_with_handler_async_result_double(False, double_handler)
+        obj.method_with_handler_async_result_boolean(False, boolean_handler)
+        obj.method_with_handler_async_result_char(False, char_handler)
+        obj.method_with_handler_async_result_string(False, string_handler)
+        self.assertEqual(dct['count'], 9)
+
+
+    def testMethodWithHandlerAsyncResultBasicTypesFails(self):
+        dct = dict(count=0)
+        def handler(x, err):
+            self.assertIsNone(x);
+            self.assertIsNotNone(err);
+            self.assertEqual("foobar!", err.getMessage());
+            dct['count'] += 1
+
+        obj.method_with_handler_async_result_byte(True, handler)
+        obj.method_with_handler_async_result_short(True, handler)
+        obj.method_with_handler_async_result_integer(True, handler)
+        obj.method_with_handler_async_result_long(True, handler)
+        obj.method_with_handler_async_result_float(True, handler)
+        obj.method_with_handler_async_result_double(True, handler)
+        obj.method_with_handler_async_result_boolean(True, handler)
+        obj.method_with_handler_async_result_char(True, handler)
+        obj.method_with_handler_async_result_string(True, handler)
+        self.assertEqual(dct['count'], 9)
+
+    def testMethodWithUserTypes(self):
+        refed_obj.set_string('aardvarks')
+        obj.method_with_user_types(refed_obj)
+
+
+    def testObjectParam(self):
+        obj.method_with_object_param('null', None)
+        obj.method_with_object_param('string', 'wibble')
+        obj.method_with_object_param('true', True)
+        obj.method_with_object_param('false', False)
+        obj.method_with_object_param('long', 123)
+        obj.method_with_object_param('double', 123.456)
+        json_obj = {"foo" : "hello", "bar" : 123}
+        obj.method_with_object_param('JsonObject', json_obj)
+        json_arr = ["foo", "bar", "wib"]
+        obj.method_with_object_param('JsonArray', json_arr)
+
+
+    def testDataObjectParam(self):
+        data_object = {"foo" : "Hello", "bar" : 123, "wibble" : 1.23}
+        obj.method_with_data_object_param(data_object)
+
+
+    def testNullDataObjectParam(self):
+        data_object = {}
+        obj.method_with_null_data_object_param(data_object=data_object)
+
+
+    def testMethodWithHandlerDataObject(self):
+        dct = dict(count=0)
+        def handler(option):
+            self.assertEqual("foo", option.foo)
+            self.assertEqual(123, option.bar)
+            self.assertEqual(0.0, option.wibble)
+            dct['count'] += 1
+        obj.method_with_handler_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultDataObject(self):
+        dct = dict(count=0)
+        def handler(option, err):
+            self.assertIsNone(option);
+            self.assertIsNotNone(err);
+            self.assertEqual("foobar!", err.getMessage());
+            dct['count'] += 1;
+        self.assertEqual(dct['count'], 1)
+
+
+    #def testMethodWithHandlerAsyncResultDataObjectFails(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_data_object(true) { |err,val| self.is_nil(val); Assert.is_not_nil(err); Assert.equals(err.message, 'foobar!'); dct['count'] += 1 }
+        #self.equals(count, 1)
+
+
+    #def testMethodWithHandlerListAndSet(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_and_set(
+            #Proc.new { |val| self.equals(val, %w(foo bar wibble)); dct['count'] += 1 },
+            #Proc.new { |val| self.equals(val, [5,12,100]); dct['count'] += 1 },
+            #Proc.new { |val| self.equals(val, Set.new(%w(foo bar wibble))); dct['count'] += 1 }) do |val|
+          #self.equals(val, Set.new([5,12,100])); dct['count'] += 1
+        #end
+        #self.equals(4, count)
+
+
+    #def testMethodWithHandlerAsyncResultListAndSet(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_string { |err,val| self.is_nil(err); Assert.equals(val, %w(foo bar wibble)); dct['count'] += 1 }
+        #obj.method_with_handler_async_result_list_integer { |err,val| self.is_nil(err); Assert.equals(val, [5,12,100]); dct['count'] += 1 }
+        #obj.method_with_handler_async_result_set_string { |err,val| self.is_nil(err); Assert.equals(val, Set.new(%w(foo bar wibble))); dct['count'] += 1 }
+        #obj.method_with_handler_async_result_set_integer { |err,val| self.is_nil(err); Assert.equals(val, Set.new([5,12,100])); dct['count'] += 1 }
+        #self.equals(4, count)
+
+
+    #def testMethodWithHandlerListVertxGen(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_vertx_gen do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 2)
+          #self.equals(val[0].class, Testmodel::RefedInterface1)
+          #self.equals(val[0].get_string, 'foo')
+          #self.equals(val[1].class, Testmodel::RefedInterface1)
+          #self.equals(val[1].get_string, 'bar')
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListAbstractVertxGen(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_abstract_vertx_gen do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 2)
+          #self.equals(val[0].is_a?(Testmodel::RefedInterface2), true)
+          #self.equals(val[0].get_string, 'abstractfoo')
+          #self.equals(val[1].is_a?(Testmodel::RefedInterface2), true)
+          #self.equals(val[1].get_string, 'abstractbar')
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListVertxGen(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_vertx_gen do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 2)
+          #self.equals(val[0].class, Testmodel::RefedInterface1)
+          #self.equals(val[0].get_string, 'foo')
+          #self.equals(val[1].class, Testmodel::RefedInterface1)
+          #self.equals(val[1].get_string, 'bar')
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListAbstractVertxGen(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_abstract_vertx_gen do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 2)
+          #self.equals(val[0].is_a?(Testmodel::RefedInterface2), true)
+          #self.equals(val[0].get_string, 'abstractfoo')
+          #self.equals(val[1].is_a?(Testmodel::RefedInterface2), true)
+          #self.equals(val[1].get_string, 'abstractbar')
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetVertxGen(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_vertx_gen do |val|
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 2)
+          #val.each { |elt| self.equals(elt.class, Testmodel::RefedInterface1) }
+          #self.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetAbstractVertxGen(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_abstract_vertx_gen do |val|
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 2)
+          #val.each { |elt| self.equals(elt.is_a?(Testmodel::RefedInterface2), true) }
+          #self.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(abstractfoo abstractbar)))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetVertxGen(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_vertx_gen do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 2)
+          #val.each { |elt| self.equals(elt.class, Testmodel::RefedInterface1) }
+          #self.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetAbstractVertxGen(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_abstract_vertx_gen do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 2)
+          #val.each { |elt| self.equals(elt.is_a?(Testmodel::RefedInterface2), true) }
+          #self.equals(val.map { |o| o.get_string }.to_set, Set.new(%w(abstractfoo abstractbar)))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_json_object do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 2)
+          #self.equals(val[0].class, Hash)
+          #self.equals(val[0], {'cheese' => 'stilton'})
+          #self.equals(val[1].class, Hash)
+          #self.equals(val[1], {'socks' => 'tartan'})
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListNullJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_null_json_object do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 1)
+          #self.equals(val[0], nil)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListComplexJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_complex_json_object do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 1)
+          #self.equals(val[0], {'outer' => {'socks' => 'tartan'}, 'list' => ['yellow', 'blue']})
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_json_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 2)
+          #self.equals(val[0].class, Hash)
+          #self.equals(val[0], {'cheese' => 'stilton'})
+          #self.equals(val[1].class, Hash)
+          #self.equals(val[1], {'socks' => 'tartan'})
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListNullJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_null_json_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 1)
+          #self.equals(val[0], nil)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListComplexJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_complex_json_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 1)
+          #self.equals(val[0], {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']})
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_json_object do |val|
+          #self.equals(val.class, Set)
+          #val.each { |elt| self.equals(elt.is_a?(Hash), true) }
+          #self.equals(val, Set.new([{'cheese' => 'stilton'},{'socks' => 'tartan'}]))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetNullJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_null_json_object do |val|
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 1)
+          #val.each { |elt| self.is_nil(elt) }
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetComplexJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_complex_json_object do |val|
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 1)
+          #self.equals(val, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_json_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Set)
+          #val.each { |elt| self.equals(elt.is_a?(Hash), true) }
+          #self.equals(val, Set.new([{'cheese' => 'stilton'},{'socks' => 'tartan'}]))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetNullJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_null_json_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 1)
+          #val.each { |elt| self.is_nil(elt) }
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetComplexJsonObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_complex_json_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 1)
+          #self.equals(val, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_json_array do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 2)
+          #self.equals(val[0].class, Array)
+          #self.equals(val[0], %w(green blue))
+          #self.equals(val[1].class, Array)
+          #self.equals(val[1], %w(yellow purple))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListNullJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_null_json_array do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 1)
+          #self.equals(val[0], nil)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_json_array do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 2)
+          #self.equals(val[0].class, Array)
+          #self.equals(val[0], %w(green blue))
+          #self.equals(val[1].class, Array)
+          #self.equals(val[1], %w(yellow purple))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListNullJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_null_json_array do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val.size, 1)
+          #self.equals(val[0], nil)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListComplexJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_complex_json_array do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_json_array do |val|
+          #self.equals(val.class, Set)
+          #val.each { |elt| self.equals(elt.is_a?(Array), true) }
+          #self.equals(val, Set.new([%w(green blue), %w(yellow purple)]))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetNullJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_null_json_array do |val|
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 1)
+          #val.each { |elt| self.is_nil(elt) }
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetComplexJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_complex_json_array do |val|
+          #self.equals(val.class, Set)
+          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_json_array do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Set)
+          #val.each { |elt| self.equals(elt.is_a?(Array), true) }
+          #self.equals(val, Set.new([%w(green blue), %w(yellow purple)]))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetNullJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_null_json_array do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Set)
+          #self.equals(val.size, 1)
+          #val.each { |elt| self.is_nil(elt) }
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListComplexJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_complex_json_array do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListDataObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_data_object do |val|
+          #self.equals(val.class, Array)
+          #val.each { |elt| self.equals(elt.is_a?(Hash), true) }
+          #self.equals(val[0], {'foo'=>'String 1','bar'=>1,'wibble'=>1.1})
+          #self.equals(val[1], {'foo'=>'String 2','bar'=>2,'wibble'=>2.2})
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerListNullDataObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_list_null_data_object do |val|
+          #self.equals(val.class, Array)
+          #self.equals(val[0], nil)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerSetDataObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_data_object do |val|
+          #self.equals(val, Set.new([{'foo'=>'String 1','bar'=>1,'wibble'=>1.1},{'foo'=>'String 2','bar'=>2,'wibble'=>2.2}]))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerNullSetDataObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_set_null_data_object do |val|
+          #self.equals(val, Set.new([nil]))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetComplexJsonArray(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_complex_json_array do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Set)
+          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListDataObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_data_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #val.each { |elt| self.equals(elt.is_a?(Hash), true) }
+          #self.equals(val[0], {'foo'=>'String 1','bar'=>1,'wibble'=>1.1})
+          #self.equals(val[1], {'foo'=>'String 2','bar'=>2,'wibble'=>2.2})
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultListNullDataObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_list_null_data_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Array)
+          #self.equals(val[0], nil)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultSetDataObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_data_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val, Set.new([{'foo'=>'String 1','bar'=>1,'wibble'=>1.1},{'foo'=>'String 2','bar'=>2,'wibble'=>2.2}]))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultNullSetDataObject(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_set_null_data_object do |err,val|
+          #self.is_nil(err)
+          #self.equals(val, Set.new([nil]))
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerUserTypes(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_user_types do |val|
+          #self.equals(val.class, Testmodel::RefedInterface1)
+          #self.equals(val.get_string, 'echidnas')
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultUserTypes(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_user_types do |err,val|
+          #self.is_nil(err)
+          #self.equals(val.class, Testmodel::RefedInterface1)
+          #self.equals(val.get_string, 'cheetahs')
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithConcreteHandlerUserTypeSubtype(self):
+        #dct = dict(count=0)
+        #arg = Testmodel::Factory.create_concrete_handler_user_type do |refedObj|
+          #self.equals(refedObj.class, Testmodel::RefedInterface1)
+          #self.equals(refedObj.get_string, 'echidnas')
+          #dct['count'] += 1
+        #end
+        #obj.method_with_concrete_handler_user_type_subtype arg
+        #self.equals(1, count)
+
+
+    #def testMethodWithAbstractHandlerUserTypeSubtype(self):
+        #dct = dict(count=0)
+        #arg = Testmodel::Factory.create_abstract_handler_user_type do |refedObj|
+          #self.equals(refedObj.class, Testmodel::RefedInterface1)
+          #self.equals(refedObj.get_string, 'echidnas')
+          #dct['count'] += 1
+        #end
+        #obj.method_with_abstract_handler_user_type_subtype arg
+        #self.equals(1, count)
+
+
+    #def testMethodWithConcreteHandlerUserTypeSubtypeExtension(self):
+        #dct = dict(count=0)
+        #arg = Testmodel::Factory.create_concrete_handler_user_type_extension do |refedObj|
+          #self.equals(refedObj.class, Testmodel::RefedInterface1)
+          #self.equals(refedObj.get_string, 'echidnas')
+          #dct['count'] += 1
+        #end
+        #obj.method_with_concrete_handler_user_type_subtype_extension arg
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerVoid(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_void do |val|
+          #self.is_nil(val)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultVoid(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_void(false) do |err|
+          #self.is_nil(err)
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerAsyncResultVoidFails(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_void(true) do |err|
+          #self.is_not_nil err
+          #self.equals(err.message, 'foo!')
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerThrowable(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_throwable do |err|
+          #self.is_not_nil err
+          #self.equals(err.message, 'cheese!')
+          #dct['count'] += 1
+        #end
+        #self.equals(1, count)
+
+
+    #def testMethodWithHandlerGenericUserType(self):
+        #def run_test(value, &assert)(self):
+          #dct = dict(count=0)
+          #obj.method_with_handler_generic_user_type(value) do |refedObj|
+            #self.is_not_nil(refedObj)
+            #self.equals(refedObj.class, Testmodel::GenericRefedInterface)
+            #assert.call(refedObj.get_value)
+            #dct['count'] += 1
+          #end
+          #self.equals(1, count)
+        #end
+        #run_test('string_value') { |value| self.equals(value, 'string_value') }
+        #run_test({'key' => 'key_value'}) { |value| self.equals(value, {'key' => 'key_value'}) }
+        #run_test(%w(foo bar juu)) { |value| self.equals(value, %w(foo bar juu)) }
+
+
+    #def testMethodWithHandlerAsyncResultGenericUserType(self):
+        #def run_test(value, &assert)(self):
+          #dct = dict(count=0)
+          #obj.method_with_handler_async_result_generic_user_type(value) do |err,refedObj|
+            #self.is_nil(err)
+            #self.is_not_nil(refedObj)
+            #self.equals(refedObj.class, Testmodel::GenericRefedInterface)
+            #assert.call(refedObj.get_value)
+            #dct['count'] += 1
+          #end
+          #self.equals(1, count)
+        #end
+        #run_test('string_value') { |value| self.equals(value, 'string_value') }
+        #run_test({'key' => 'key_value'}) { |value| self.equals(value, {'key' => 'key_value'}) }
+        #run_test(%w(foo bar juu)) { |value| self.equals(value, %w(foo bar juu)) }
+
+
+    #def testMethodWithGenericParam(self):
+        #obj.method_with_generic_param 'String', 'foo'
+        #obj.method_with_generic_param 'JsonObject', {'foo'=>'hello','bar'=>123}
+        #obj.method_with_generic_param 'JsonArray', ['foo', 'bar', 'wib']
+
+
+    #def testMethodWithGenericHandler(self):
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler('String') { |val| self.equals(val.class, String); Assert.equals(val, 'foo'); dct['count'] += 1 }
+        #self.equals(1, count)
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler('Ref') { |val| self.equals(val.getString, 'bar'); dct['count'] += 1 }
+        #self.equals(1, count)
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler('JsonObject') { |val| self.equals(val.class, Hash); Assert.equals(val, {'foo'=>'hello','bar'=>123}); dct['count'] += 1 }
+        #self.equals(1, count)
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler('JsonArray') { |val| self.equals(val.class, Array); Assert.equals(val, ['foo','bar','wib']); dct['count'] += 1 }
+        #self.equals(1, count)
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler('JsonObjectComplex') { |val| self.equals(val.class, Hash); Assert.equals(val, {'outer' => {'foo' => 'hello'}, 'bar'=> ['this', 'that']}); dct['count'] += 1 }
+        #self.equals(1, count)
+
+
+    #def testMethodWithGenericHandlerAsyncResult(self):
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler_async_result('String') { |err,val| self.is_nil(err); Assert.equals(val.class, String); Assert.equals(val, 'foo'); dct['count'] += 1 }
+        #self.equals(1, count)
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler_async_result('Ref') { |err,val| self.is_nil(err); Assert.equals(val.getString, 'bar'); dct['count'] += 1 }
+        #self.equals(1, count)
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler_async_result('JsonObject') { |err,val| self.is_nil(err); Assert.equals(val.class, Hash); Assert.equals(val, {'foo'=>'hello','bar'=>123}); dct['count'] += 1 }
+        #self.equals(1, count)
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler_async_result('JsonObjectComplex') { |err,val| self.is_nil(err); Assert.equals(val.class, Hash); Assert.equals(val, {'outer' => {'foo' => 'hello'}, 'bar'=> ['this', 'that']}); dct['count'] += 1 }
+        #self.equals(1, count)
+        #dct = dict(count=0)
+        #obj.method_with_generic_handler_async_result('JsonArray') { |err,val| self.is_nil(err); Assert.equals(val.class, Array); Assert.equals(val, ['foo','bar','wib']); dct['count'] += 1 }
+        #self.equals(1, count)
+
+
+    #def testBasicReturns(self):
+        #ret = obj.method_with_byte_return
+        #self.equals(ret.class, Fixnum)
+        #self.equals(ret, 123)
+        #ret = obj.method_with_short_return
+        #self.equals(ret.class, Fixnum)
+        #self.equals(ret, 12345)
+        #ret = obj.method_with_int_return
+        #self.equals(ret.class, Fixnum)
+        #self.equals(ret, 12345464)
+        #ret = obj.method_with_long_return
+        #self.equals(ret.class, Fixnum)
+        #self.equals(ret, 65675123)
+        #ret = obj.method_with_float_return
+        #self.equals(ret.class, Float)
+        #self.equals(ret, 1.23)
+        #ret = obj.method_with_double_return
+        #self.equals(ret.class, Float)
+        #self.equals(ret, 3.34535)
+        #ret = obj.method_with_boolean_return?
+        #self.equals(ret.class, TrueClass)
+        #self.equals(ret, true)
+        #ret = obj.method_with_char_return
+        #self.equals(ret.class, Fixnum)
+        #self.equals(ret, 89)
+        #ret = obj.method_with_string_return
+        #self.equals(ret.class, String)
+        #self.equals(ret, 'orangutan')
+
+
+    #def testVertxGenReturn(self):
+        #ret = obj.method_with_vertx_gen_return
+        #self.equals(ret.class, Testmodel::RefedInterface1)
+        #self.equals(ret.get_string, 'chaffinch')
+
+
+    #def testVertxGenNullReturn(self):
+        #ret = obj.method_with_vertx_gen_null_return
+        #self.equals(nil, ret)
+
+
+    #def testAbstractVertxGenReturn(self):
+        #ret = obj.method_with_abstract_vertx_gen_return
+        #self.equals(ret.is_a?(Testmodel::RefedInterface2), true)
+        #self.equals(ret.get_string, 'abstractchaffinch')
+
+
+    #def testMapComplexJsonArrayReturn(self):
+        #map = obj.method_with_map_complex_json_array_return {}
+        #m = map['foo']
+        #self.equals m, [{'foo' => 'hello'}, {'bar' => 'bye'}]
+
+
+    #def testOverloadedMethods(self):
+        #@refed_obj.set_string('dog')
+        #called = false
+        #ret = obj.overloaded_method('cat', @refed_obj)
+        #self.equals(ret, 'meth1')
+        #ret = obj.overloaded_method('cat', @refed_obj, 12345) { |animal| self.equals(animal, 'giraffe') ; called = true }
+        #self.equals(ret, 'meth2')
+        #self.equals(called, true)
+        #called = false
+        ## for some reason animal is sometimes equals to giraffe and sometimes empty
+        #ret = obj.overloaded_method('cat') { |animal| called = true }
+        #self.equals(ret, 'meth3')
+        #self.equals(called, true)
+        #called = false
+        #ret = obj.overloaded_method('cat', @refed_obj) { |animal| self.equals(animal, 'giraffe') ; called = true }
+        #self.equals(ret, 'meth4')
+        #self.equals(called, true)
+        #self.argument_error { obj.overloaded_method 'cat' }
+        #self.argument_error { obj.overloaded_method('cat', @refed_obj, 12345) }
+        #self.argument_error { obj.overloaded_method {} }
+
+
+    #def testSuperInterfaces(self):
+        #obj.super_method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
+        #self.equals(obj.is_a?(Testmodel::SuperInterface1), true)
+        #obj.other_super_method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
+        #self.equals(obj.is_a?(Testmodel::SuperInterface2), true)
+
+
+    #def testMethodWithGenericReturn(self):
+        #ret = obj.method_with_generic_return('JsonObject')
+        #self.equals(ret.class, Hash)
+        #self.equals(ret, {'foo'=>'hello','bar'=>123})
+        #ret = obj.method_with_generic_return('JsonArray')
+        #self.equals(ret.class, Array)
+        #self.equals(ret, %w(foo bar wib))
+
+
+    #def testFluentMethod(self):
+        #ret = obj.fluent_method('bar')
+        #self.equals(ret, obj)
+
+
+    #def testStaticFactoryMethod(self):
+        #ret = Testmodel::TestInterface.static_factory_method('bar')
+        #self.equals(ret.class, Testmodel::RefedInterface1)
+        #self.equals(ret.get_string, 'bar')
+
+
+    #def testMethodWithCachedReturn(self):
+        #ret = obj.method_with_cached_return('bar')
+        #ret2 = obj.method_with_cached_return('bar')
+        #self.equals ret, ret2
+        #ret3 = obj.method_with_cached_return('bar')
+        #self.equals ret, ret3
+        #self.equals ret.get_string, 'bar'
+        #self.equals ret2.get_string, 'bar'
+        #self.equals ret3.get_string, 'bar'
+        #ret.set_string 'foo'
+        #self.equals ret2.get_string, 'foo'
+        #self.equals ret3.get_string, 'foo'
+
+
+    #def testJsonReturns(self):
+        #ret = obj.method_with_json_object_return
+        #self.equals(ret, {'cheese'=>'stilton'})
+        #ret = obj.method_with_json_array_return
+        #self.equals(ret, %w(socks shoes))
+
+
+    #def testNullJsonReturns(self):
+        #ret = obj.method_with_null_json_object_return
+        #self.is_nil(ret)
+        #ret = obj.method_with_null_json_array_return
+        #self.is_nil(ret)
+
+
+    #def testComplexJsonReturns(self):
+        #ret = obj.method_with_complex_json_object_return
+        #self.equals ret, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}
+        #ret = obj.method_with_complex_json_array_return
+        #self.equals ret, [{'foo' => 'hello'}, {'bar' => 'bye'}]
+
+
+    #def testJsonParams(self):
+        #obj.method_with_json_params({'cat' => 'lion', 'cheese' => 'cheddar'}, %w(house spider))
+
+
+    #def testNullJsonParams(self):
+        #self.argument_error { obj.method_with_null_json_params(nil, nil) }
+
+
+    #def testJsonHandlerParams(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_json(
+            #Proc.new { |val| self.equals(val, {'cheese'=>'stilton'}); dct['count'] += 1 }) do  |val|
+          #self.equals(val, %w(socks shoes)); dct['count'] += 1
+        #end
+        #self.equals(2, count)
+
+
+    #def testNullJsonHandlerParams(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_null_json(
+            #Proc.new { |val| self.is_nil(val); dct['count'] += 1 }) do |val|
+          #self.is_nil(val); dct['count'] += 1
+        #end
+        #self.equals(2, count)
+
+
+    #def testComplexJsonHandlerParams(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_complex_json(
+            #Proc.new { |val| self.equals(val, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}); dct['count'] += 1 }) do |val|
+          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
+          #dct['count'] += 1
+        #end
+        #self.equals(2, count)
+
+
+    #def testJsonHandlerAsyncResultParams(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_json_object { |err,val| self.is_nil(err); Assert.equals(val, {'cheese'=>'stilton'}); dct['count'] += 1 }
+        #obj.method_with_handler_async_result_json_array { |err,val| self.is_nil(err); Assert.equals(val, ['socks','shoes']); dct['count'] += 1 }
+        #self.equals(2, count)
+
+
+    #def testNullJsonHandlerAsyncResultParams(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_null_json_object { |err,val| self.is_nil(err); Assert.is_nil(val); dct['count'] += 1 }
+        #obj.method_with_handler_async_result_null_json_array { |err,val| self.is_nil(err); Assert.is_nil(val); dct['count'] += 1 }
+        #self.equals(2, count)
+
+
+    #def testEnumParam(self):
+        #ret = obj.method_with_enum_param('sausages', :TIM)
+        #self.equals(ret, 'sausagesTIM')
+
+
+    #def testEnumReturn(self):
+        #ret = obj.method_with_enum_return('JULIEN')
+        #self.equals(:JULIEN, ret)
+
+
+    #def testMapReturn(self):
+        #readLog = []
+        #writeLog = []
+        #map = obj.method_with_map_return{ |op|
+          #if op =~ /put\([^,]+,[^\)]+\)/ || op =~ /remove\([^\)]+\)/ || op == 'clear()'
+            #writeLog.push op
+          #elsif op == 'size()' || op =~ /get\([^\)]+\)/ || op == 'entrySet()'
+            #readLog.push op
+          #else
+            #raise "unsupported #{op}"
+          #end
+        #}
+        #map['foo'] = 'bar'
+        #self.equals writeLog, ['put(foo,bar)']
+        #readLog.clear
+        #writeLog.clear
+        #self.equals map['foo'], 'bar'
+        #self.is_not_nil readLog.index('get(foo)')
+        #self.equals writeLog, []
+        #map['wibble'] = 'quux'
+        #readLog.clear
+        #writeLog.clear
+        #self.equals map.size, 2
+        #self.equals map['wibble'], 'quux'
+        #self.is_not_nil readLog.index('size()')
+        #self.equals writeLog, []
+        #readLog.clear
+        #writeLog.clear
+        #map.delete('wibble')
+        #self.equals writeLog, ['remove(wibble)']
+        #self.equals map.size, 1
+        #map['blah'] = '123'
+        #key_dct = dict(count=0)
+        #readLog.clear
+        #writeLog.clear
+        #map.each { |k,v|
+          #if key_count == 0
+            #self.equals k, 'foo'
+            #self.equals v, 'bar'
+            #key_dct['count'] += 1
+          #else
+            #self.equals k, 'blah'
+            #self.equals v, '123'
+          #end
+        #}
+        #self.is_not_nil readLog.index('entrySet()')
+        #self.equals writeLog, []
+        #readLog.clear
+        #writeLog.clear
+        #map.clear
+        #self.equals writeLog, ['clear()']
+
+
+    #def testMapStringReturn(self):
+        #map = obj.method_with_map_string_return {}
+        #val = map['foo']
+        #self.equals val.class, String
+        #self.equals val, 'bar'
+        #map['juu'] = 'daa'
+        #self.equals map, {'foo'=>'bar','juu'=>'daa'}
+        #self.argument_error { map['wibble'] = 123 }
+        #self.equals map, {'foo'=>'bar','juu'=>'daa'}
+
+
+    #def testMapJsonObjectReturn(self):
+        #map = obj.method_with_map_json_object_return {}
+        #json = map['foo']
+        #self.equals json.class, Hash
+        #self.equals json['wibble'], 'eek'
+        #map['bar'] = {'juu'=>'daa'}
+        #self.equals map, {'foo'=>{'wibble'=>'eek'},'bar'=>{'juu'=>'daa'}}
+        #self.argument_error { map['juu'] = 123 }
+        #self.equals map, {'foo'=>{'wibble'=>'eek'},'bar'=>{'juu'=>'daa'}}
+
+
+    #def testMapComplexJsonObjectReturn(self):
+        #map = obj.method_with_map_complex_json_object_return {}
+        #m = map['foo']
+        #self.equals m, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}
+
+
+    #def testMapJsonArrayReturn(self):
+        #map = obj.method_with_map_json_array_return {}
+        #arr = map['foo']
+        #self.equals arr.class, Array
+        #self.equals arr, ['wibble']
+        #map['bar'] = ['spidey']
+        #self.equals map, {'foo'=>['wibble'],'bar'=>['spidey']}
+        #self.argument_error { map['juu'] = 123 }
+        #self.equals map, {'foo'=>['wibble'],'bar'=>['spidey']}
+
+
+    #def testMapLongReturn(self):
+        #map = obj.method_with_map_long_return {}
+        #num = map['foo']
+        #self.equals num.class, Fixnum
+        #self.equals num, 123
+        #map['bar'] = 321
+        #self.equals map, {'foo'=>123,'bar'=>321}
+        #self.argument_error { map['juu'] = 'something' }
+        #self.equals map, {'foo'=>123,'bar'=>321}
+
+
+    #def testMapIntegerReturn(self):
+        #map = obj.method_with_map_integer_return {}
+        #num = map['foo']
+        #self.equals num.class, Fixnum
+        #self.equals num, 123
+        #map['bar'] = 321
+        #self.equals map, {'foo'=>123,'bar'=>321}
+        #self.argument_error { map['juu'] = 'something' }
+        #self.equals map, {'foo'=>123,'bar'=>321}
+
+
+    #def testMapShortReturn(self):
+        #map = obj.method_with_map_short_return {}
+        #num = map['foo']
+        #self.equals num.class, Fixnum
+        #self.equals num, 123
+        #map['bar'] = 321
+        #self.equals map, {'foo'=>123,'bar'=>321}
+        #self.argument_error { map['juu'] = 'something' }
+        #self.equals map, {'foo'=>123,'bar'=>321}
+
+
+    #def testMapByteReturn(self):
+        #map = obj.method_with_map_byte_return {}
+        #num = map['foo']
+        #self.equals num.class, Fixnum
+        #self.equals num, 123
+        #map['bar'] = 12
+        #self.equals map, {'foo'=>123,'bar'=>12}
+        #self.argument_error { map['juu'] = 'something' }
+        #self.equals map, {'foo'=>123,'bar'=>12}
+
+
+    #def testMapCharacterReturn(self):
+        #map = obj.method_with_map_character_return {}
+        #num = map['foo']
+        #self.equals num.class, Fixnum
+        #self.equals num, 88
+        #map['bar'] = 89
+        #self.equals map, {'foo'=>88,'bar'=>89}
+        #self.argument_error { map['juu'] = 'something' }
+        #self.equals map, {'foo'=>88,'bar'=>89}
+
+
+    #def testMapBooleanReturn(self):
+        #map = obj.method_with_map_boolean_return {}
+        #num = map['foo']
+        #self.equals num.class, TrueClass
+        #self.equals num, true
+        #map['bar'] = false
+        #self.equals map, {'foo'=>true,'bar'=>false}
+        #map['juu'] = 'something'
+        #map['daa'] = nil
+        #self.equals map, {'foo'=>true,'bar'=>false,'juu'=>true,'daa'=>false}
+
+
+    #def testMapFloatReturn(self):
+        #map = obj.method_with_map_float_return {}
+        #num = map['foo']
+        #self.equals num.class, Float
+        #self.equals num, 0.123
+        #map['bar'] = 0.321
+        #self.equals map['foo'], 0.123
+        #self.equals map['bar'], 0.321
+        #self.equals map.keys.sort, %w(bar foo)
+        #self.argument_error { map['juu'] = 'something' }
+        #self.equals map['foo'], 0.123
+        #self.equals map['bar'], 0.321
+        #self.equals map.keys.sort, %w(bar foo)
+
+
+    #def testMapDoubleReturn(self):
+        #map = obj.method_with_map_double_return {}
+        #num = map['foo']
+        #self.equals num.class, Float
+        #self.equals num, 0.123
+        #map['bar'] = 0.321
+        #self.equals map, {'foo'=>0.123,'bar'=>0.321}
+        #self.argument_error { map['juu'] = 'something' }
+        #self.equals map, {'foo'=>0.123,'bar'=>0.321}
+
+
+    #def testMapNullReturn(self):
+        #map = obj.method_with_null_map_return
+        #self.is_nil map
+
+
+    #def testListStringReturn(self):
+        #ret = obj.method_with_list_string_return
+        #self.has_class ret, Array
+        #self.equals ret, %w(foo bar wibble)
+
+
+    #def testListLongReturn(self):
+        #ret = obj.method_with_list_long_return
+        #self.has_class ret, Array
+        #self.equals ret, [123,456]
+
+
+    #def testListJsonObjectReturn(self):
+        #ret = obj.method_with_list_json_object_return
+        #self.has_class ret, Array
+        #self.equals ret, [{'foo'=>'bar'},{'blah'=>'eek'}]
+
+
+    #def testListComplexJsonObjectReturn(self):
+        #ret = obj.method_with_list_complex_json_object_return
+        #self.has_class ret, Array
+        #self.equals ret, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}]
+
+
+    #def testListJsonArrayReturn(self):
+        #ret = obj.method_with_list_json_array_return
+        #self.has_class ret, Array
+        #self.equals ret, [['foo'],['blah']]
+
+
+    #def testListComplexJsonArrayReturn(self):
+        #ret = obj.method_with_list_complex_json_array_return
+        #self.has_class ret, Array
+        #self.equals ret, [[{'foo' => 'hello'}],[{'bar' => 'bye'}]]
+
+
+    #def testListVertxGenReturn(self):
+        #ret = obj.method_with_list_vertx_gen_return
+        #self.has_class ret, Array
+        #self.has_class ret[0], Testmodel::RefedInterface1
+        #self.equals ret[0].get_string, 'foo'
+        #self.has_class ret[1], Testmodel::RefedInterface1
+        #self.equals ret[1].get_string, 'bar'
+
+
+    #def testSetStringReturn(self):
+        #ret = obj.method_with_set_string_return
+        #self.has_class ret, Set
+        #self.equals ret, Set.new(%w(foo bar wibble))
+
+
+    #def testSetLongReturn(self):
+        #ret = obj.method_with_set_long_return
+        #self.has_class ret, Set
+        #self.equals ret, Set.new([123,456])
+
+
+    #def testSetJsonObjectReturn(self):
+        #ret = obj.method_with_set_json_object_return
+        #self.has_class ret, Set
+        #self.equals ret, Set.new([{'foo'=>'bar'},{'blah'=>'eek'}])
+
+
+    #def testSetComplexJsonObjectReturn(self):
+        #ret = obj.method_with_set_complex_json_object_return
+        #self.has_class ret, Set
+        #self.equals ret, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set
+
+
+    #def testSetJsonArrayReturn(self):
+        #ret = obj.method_with_set_json_array_return
+        #self.has_class ret, Set
+        #self.equals ret, Set.new([['foo'],['blah']])
+
+
+    #def testSetComplexJsonArrayReturn(self):
+        #ret = obj.method_with_set_complex_json_array_return
+        #self.has_class ret, Set
+        #self.equals ret, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set
+
+
+    #def testSetVertxGenReturn(self):
+        #ret = obj.method_with_set_vertx_gen_return
+        #self.has_class ret, Set
+        #ret.each { |elt| self.has_class(elt, Testmodel::RefedInterface1) }
+        #self.equals(ret.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
+
+
+    #def testComplexJsonHandlerAsyncResultParams(self):
+        #dct = dict(count=0)
+        #obj.method_with_handler_async_result_complex_json_object { |err,val|
+          #self.is_nil(err)
+          #self.equals(val, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']})
+          #dct['count'] += 1
+        #}
+        #obj.method_with_handler_async_result_complex_json_array { |err,val|
+          #self.is_nil(err)
+          #self.equals(val, [{'foo' => 'hello'}, {'bar' => 'bye'}])
+          #dct['count'] += 1
+        #}
+        #self.equals(2, count)
+
+
+    #def testThrowableReturn(self):
+        #ret = obj.method_with_throwable_return 'bogies'
+        #self.equals('bogies', ret.message)
+
+
+    #def testCustomModule(self):
+        #my = Acme::MyInterface.create
+        #test_interface = my.method
+        #test_interface.method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
+        #sub = my.sub
+        #ret = sub.reverse "hello"
+        #self.equals ret, "olleh"
+
+
+    #def testMethodWithListParams(self):
+        #obj.method_with_list_params(
+            #%w(foo bar),
+            #[2, 3],
+            #[12, 13],
+            #[1234, 1345],
+            #[123, 456],
+            #[{:foo=>'bar'}, {:eek=>'wibble'}],
+            #[['foo'], ['blah']],
+            #[Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'), Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')],
+            #[{:foo=>'String 1',:bar=>1,:wibble=>1.1}, {:foo=>'String 2',:bar=>2,:wibble=>2.2}]
+        #)
+        #self.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
+
+
+    #def testMethodWithSetParams(self):
+        #obj.method_with_set_params(
+            #Set.new(['foo', 'bar']),
+            #Set.new([2, 3]),
+            #Set.new([12, 13]),
+            #Set.new([1234, 1345]),
+            #Set.new([123, 456]),
+            #Set.new([{:foo=>'bar'}, {:eek=>'wibble'}]),
+            #Set.new([['foo'], ['blah']]),
+            #Set.new([Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'), Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')]),
+            #Set.new([{:foo=>'String 1',:bar=>1,:wibble=>1.1}, {:foo=>'String 2',:bar=>2,:wibble=>2.2}])
+        #)
+        #self.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
+
+
+    #def testMethodWithMapParams(self):
+        #obj.method_with_map_params(
+            #{'foo'=>'bar','eek'=>'wibble'},
+            #{'foo'=>2,'eek'=>3},
+            #{'foo'=>12,'eek'=>13},
+            #{'foo'=>1234,'eek'=>1345},
+            #{'foo'=>123,'eek'=>456},
+            #{'foo'=>{'foo'=>'bar'},'eek'=>{'eek'=>'wibble'}},
+            #{'foo'=>['foo'],'eek'=>['blah']},
+            #{'foo'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'),'eek'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')}
+        #)
+        #self.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
 
 
 if __name__ == "__main__":
-    meth = sys.argv[3]
-    print("calling {}".format(meth))
+    meth = sys.argv[-1]
+    print("Testing {}".format(meth))
     with util.handle_java_error():
-        globals()[meth]()
-        util.java_gateway.shutdown()
+        case = TestAPI(meth)
+        case()
+        util.vertx_shutdown()
 

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -5,11 +5,13 @@ import unittest
 from testmodel_python.testmodel.test_interface import TestInterface
 from testmodel_python.testmodel.refed_interface1 import RefedInterface1
 from testmodel_python.testmodel.refed_interface2 import RefedInterface2
+from testmodel_python.testmodel.generic_refed_interface import GenericRefedInterface
 from testmodel_python.testmodel.factory import Factory
 from acme_python.pkg.my_interface import MyInterface
 from acme_python.sub.sub_interface import SubInterface
 
 from vertx_python import util
+from vertx_python.util import frozendict
 from vertx_python.compat import long, unicode
 
 util.vertx_init()
@@ -111,12 +113,12 @@ class TestAPI(unittest.TestCase):
             self.assertIsNone(err)
             dct['count'] += 1
         def char_handler(c, err):
-            self.assertEqual(type(c), str)
+            self.assertEqual(type(c), unicode)
             self.assertEqual('X', c)
             self.assertIsNone(err)
             dct['count'] += 1
         def string_handler(s, err):
-            self.assertEqual(type(s), str)
+            self.assertEqual(type(s), unicode)
             self.assertEqual('quux!', s)
             self.assertIsNone(err)
             dct['count'] += 1
@@ -429,576 +431,756 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(dct['count'], 1)
 
 
-    #def testMethodWithHandlerListComplexJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_complex_json_object do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 1)
-          #self.equals(val[0], {'outer' => {'socks' => 'tartan'}, 'list' => ['yellow', 'blue']})
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultListJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_json_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 2)
-          #self.equals(val[0].class, Hash)
-          #self.equals(val[0], {'cheese' => 'stilton'})
-          #self.equals(val[1].class, Hash)
-          #self.equals(val[1], {'socks' => 'tartan'})
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultListNullJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_null_json_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 1)
-          #self.equals(val[0], nil)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultListComplexJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_complex_json_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 1)
-          #self.equals(val[0], {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']})
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerSetJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_json_object do |val|
-          #self.equals(val.class, Set)
-          #val.each { |elt| self.equals(elt.is_a?(Hash), true) }
-          #self.equals(val, Set.new([{'cheese' => 'stilton'},{'socks' => 'tartan'}]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerSetNullJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_null_json_object do |val|
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 1)
-          #val.each { |elt| self.is_nil(elt) }
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerSetComplexJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_complex_json_object do |val|
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 1)
-          #self.equals(val, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultSetJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_json_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Set)
-          #val.each { |elt| self.equals(elt.is_a?(Hash), true) }
-          #self.equals(val, Set.new([{'cheese' => 'stilton'},{'socks' => 'tartan'}]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultSetNullJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_null_json_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 1)
-          #val.each { |elt| self.is_nil(elt) }
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultSetComplexJsonObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_complex_json_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 1)
-          #self.equals(val, [{'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}].to_set)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerListJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_json_array do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 2)
-          #self.equals(val[0].class, Array)
-          #self.equals(val[0], %w(green blue))
-          #self.equals(val[1].class, Array)
-          #self.equals(val[1], %w(yellow purple))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerListNullJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_null_json_array do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 1)
-          #self.equals(val[0], nil)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultListJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_json_array do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 2)
-          #self.equals(val[0].class, Array)
-          #self.equals(val[0], %w(green blue))
-          #self.equals(val[1].class, Array)
-          #self.equals(val[1], %w(yellow purple))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultListNullJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_null_json_array do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val.size, 1)
-          #self.equals(val[0], nil)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultListComplexJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_complex_json_array do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerSetJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_json_array do |val|
-          #self.equals(val.class, Set)
-          #val.each { |elt| self.equals(elt.is_a?(Array), true) }
-          #self.equals(val, Set.new([%w(green blue), %w(yellow purple)]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerSetNullJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_null_json_array do |val|
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 1)
-          #val.each { |elt| self.is_nil(elt) }
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerSetComplexJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_complex_json_array do |val|
-          #self.equals(val.class, Set)
-          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultSetJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_json_array do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Set)
-          #val.each { |elt| self.equals(elt.is_a?(Array), true) }
-          #self.equals(val, Set.new([%w(green blue), %w(yellow purple)]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultSetNullJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_null_json_array do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Set)
-          #self.equals(val.size, 1)
-          #val.each { |elt| self.is_nil(elt) }
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerListComplexJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_complex_json_array do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerListDataObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_data_object do |val|
-          #self.equals(val.class, Array)
-          #val.each { |elt| self.equals(elt.is_a?(Hash), true) }
-          #self.equals(val[0], {'foo'=>'String 1','bar'=>1,'wibble'=>1.1})
-          #self.equals(val[1], {'foo'=>'String 2','bar'=>2,'wibble'=>2.2})
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerListNullDataObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_list_null_data_object do |val|
-          #self.equals(val.class, Array)
-          #self.equals(val[0], nil)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerSetDataObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_data_object do |val|
-          #self.equals(val, Set.new([{'foo'=>'String 1','bar'=>1,'wibble'=>1.1},{'foo'=>'String 2','bar'=>2,'wibble'=>2.2}]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerNullSetDataObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_set_null_data_object do |val|
-          #self.equals(val, Set.new([nil]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultSetComplexJsonArray(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_complex_json_array do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Set)
-          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]].to_set)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultListDataObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_data_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #val.each { |elt| self.equals(elt.is_a?(Hash), true) }
-          #self.equals(val[0], {'foo'=>'String 1','bar'=>1,'wibble'=>1.1})
-          #self.equals(val[1], {'foo'=>'String 2','bar'=>2,'wibble'=>2.2})
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultListNullDataObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_list_null_data_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Array)
-          #self.equals(val[0], nil)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultSetDataObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_data_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val, Set.new([{'foo'=>'String 1','bar'=>1,'wibble'=>1.1},{'foo'=>'String 2','bar'=>2,'wibble'=>2.2}]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultNullSetDataObject(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_set_null_data_object do |err,val|
-          #self.is_nil(err)
-          #self.equals(val, Set.new([nil]))
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultUserTypes(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_user_types do |err,val|
-          #self.is_nil(err)
-          #self.equals(val.class, Testmodel::RefedInterface1)
-          #self.equals(val.get_string, 'cheetahs')
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithConcreteHandlerUserTypeSubtype(self):
-        #dct = dict(count=0)
-        #arg = Testmodel::Factory.create_concrete_handler_user_type do |refedObj|
-          #self.equals(refedObj.class, Testmodel::RefedInterface1)
-          #self.equals(refedObj.get_string, 'echidnas')
-          #dct['count'] += 1
-        #end
-        #obj.method_with_concrete_handler_user_type_subtype arg
-        #self.equals(1, count)
-
-
-    #def testMethodWithAbstractHandlerUserTypeSubtype(self):
-        #dct = dict(count=0)
-        #arg = Testmodel::Factory.create_abstract_handler_user_type do |refedObj|
-          #self.equals(refedObj.class, Testmodel::RefedInterface1)
-          #self.equals(refedObj.get_string, 'echidnas')
-          #dct['count'] += 1
-        #end
-        #obj.method_with_abstract_handler_user_type_subtype arg
-        #self.equals(1, count)
-
-
-    #def testMethodWithConcreteHandlerUserTypeSubtypeExtension(self):
-        #dct = dict(count=0)
-        #arg = Testmodel::Factory.create_concrete_handler_user_type_extension do |refedObj|
-          #self.equals(refedObj.class, Testmodel::RefedInterface1)
-          #self.equals(refedObj.get_string, 'echidnas')
-          #dct['count'] += 1
-        #end
-        #obj.method_with_concrete_handler_user_type_subtype_extension arg
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerVoid(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_void do |val|
-          #self.is_nil(val)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultVoid(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_void(false) do |err|
-          #self.is_nil(err)
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerAsyncResultVoidFails(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_void(true) do |err|
-          #self.is_not_nil err
-          #self.equals(err.message, 'foo!')
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerThrowable(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_throwable do |err|
-          #self.is_not_nil err
-          #self.equals(err.message, 'cheese!')
-          #dct['count'] += 1
-        #end
-        #self.equals(1, count)
-
-
-    #def testMethodWithHandlerGenericUserType(self):
-        #def run_test(value, &assert)(self):
-          #dct = dict(count=0)
-          #obj.method_with_handler_generic_user_type(value) do |refedObj|
-            #self.is_not_nil(refedObj)
-            #self.equals(refedObj.class, Testmodel::GenericRefedInterface)
-            #assert.call(refedObj.get_value)
-            #dct['count'] += 1
-          #end
-          #self.equals(1, count)
-        #end
-        #run_test('string_value') { |value| self.equals(value, 'string_value') }
-        #run_test({'key' => 'key_value'}) { |value| self.equals(value, {'key' => 'key_value'}) }
-        #run_test(%w(foo bar juu)) { |value| self.equals(value, %w(foo bar juu)) }
-
-
-    #def testMethodWithHandlerAsyncResultGenericUserType(self):
-        #def run_test(value, &assert)(self):
-          #dct = dict(count=0)
-          #obj.method_with_handler_async_result_generic_user_type(value) do |err,refedObj|
-            #self.is_nil(err)
-            #self.is_not_nil(refedObj)
-            #self.equals(refedObj.class, Testmodel::GenericRefedInterface)
-            #assert.call(refedObj.get_value)
-            #dct['count'] += 1
-          #end
-          #self.equals(1, count)
-        #end
-        #run_test('string_value') { |value| self.equals(value, 'string_value') }
-        #run_test({'key' => 'key_value'}) { |value| self.equals(value, {'key' => 'key_value'}) }
-        #run_test(%w(foo bar juu)) { |value| self.equals(value, %w(foo bar juu)) }
-
-
-    #def testMethodWithGenericParam(self):
-        #obj.method_with_generic_param 'String', 'foo'
-        #obj.method_with_generic_param 'JsonObject', {'foo'=>'hello','bar'=>123}
-        #obj.method_with_generic_param 'JsonArray', ['foo', 'bar', 'wib']
-
-
-    #def testMethodWithGenericHandler(self):
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler('String') { |val| self.equals(val.class, String); Assert.equals(val, 'foo'); dct['count'] += 1 }
-        #self.equals(1, count)
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler('Ref') { |val| self.equals(val.getString, 'bar'); dct['count'] += 1 }
-        #self.equals(1, count)
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler('JsonObject') { |val| self.equals(val.class, Hash); Assert.equals(val, {'foo'=>'hello','bar'=>123}); dct['count'] += 1 }
-        #self.equals(1, count)
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler('JsonArray') { |val| self.equals(val.class, Array); Assert.equals(val, ['foo','bar','wib']); dct['count'] += 1 }
-        #self.equals(1, count)
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler('JsonObjectComplex') { |val| self.equals(val.class, Hash); Assert.equals(val, {'outer' => {'foo' => 'hello'}, 'bar'=> ['this', 'that']}); dct['count'] += 1 }
-        #self.equals(1, count)
-
-
-    #def testMethodWithGenericHandlerAsyncResult(self):
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler_async_result('String') { |err,val| self.is_nil(err); Assert.equals(val.class, String); Assert.equals(val, 'foo'); dct['count'] += 1 }
-        #self.equals(1, count)
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler_async_result('Ref') { |err,val| self.is_nil(err); Assert.equals(val.getString, 'bar'); dct['count'] += 1 }
-        #self.equals(1, count)
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler_async_result('JsonObject') { |err,val| self.is_nil(err); Assert.equals(val.class, Hash); Assert.equals(val, {'foo'=>'hello','bar'=>123}); dct['count'] += 1 }
-        #self.equals(1, count)
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler_async_result('JsonObjectComplex') { |err,val| self.is_nil(err); Assert.equals(val.class, Hash); Assert.equals(val, {'outer' => {'foo' => 'hello'}, 'bar'=> ['this', 'that']}); dct['count'] += 1 }
-        #self.equals(1, count)
-        #dct = dict(count=0)
-        #obj.method_with_generic_handler_async_result('JsonArray') { |err,val| self.is_nil(err); Assert.equals(val.class, Array); Assert.equals(val, ['foo','bar','wib']); dct['count'] += 1 }
-        #self.equals(1, count)
-
-
-    #def testBasicReturns(self):
-        #ret = obj.method_with_byte_return
-        #self.equals(ret.class, Fixnum)
-        #self.equals(ret, 123)
-        #ret = obj.method_with_short_return
-        #self.equals(ret.class, Fixnum)
-        #self.equals(ret, 12345)
-        #ret = obj.method_with_int_return
-        #self.equals(ret.class, Fixnum)
-        #self.equals(ret, 12345464)
-        #ret = obj.method_with_long_return
-        #self.equals(ret.class, Fixnum)
-        #self.equals(ret, 65675123)
-        #ret = obj.method_with_float_return
-        #self.equals(ret.class, Float)
-        #self.equals(ret, 1.23)
-        #ret = obj.method_with_double_return
-        #self.equals(ret.class, Float)
-        #self.equals(ret, 3.34535)
-        #ret = obj.method_with_boolean_return?
-        #self.equals(ret.class, TrueClass)
-        #self.equals(ret, true)
-        #ret = obj.method_with_char_return
-        #self.equals(ret.class, Fixnum)
-        #self.equals(ret, 89)
-        #ret = obj.method_with_string_return
-        #self.equals(ret.class, String)
-        #self.equals(ret, 'orangutan')
-
-
-    #def testVertxGenReturn(self):
-        #ret = obj.method_with_vertx_gen_return
-        #self.equals(ret.class, Testmodel::RefedInterface1)
-        #self.equals(ret.get_string, 'chaffinch')
-
-
-    #def testVertxGenNullReturn(self):
-        #ret = obj.method_with_vertx_gen_null_return
-        #self.equals(nil, ret)
-
-
-    #def testAbstractVertxGenReturn(self):
-        #ret = obj.method_with_abstract_vertx_gen_return
-        #self.equals(ret.is_a?(Testmodel::RefedInterface2), true)
-        #self.equals(ret.get_string, 'abstractchaffinch')
+    def testMethodWithHandlerListComplexJsonObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 1)
+            self.assertEqual(val[0], {'outer' : {'socks' : 'tartan'}, 'list' : ['yellow', 'blue']})
+            dct['count'] += 1
+        obj.method_with_handler_list_complex_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultListJsonObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 2)
+            self.assertEqual(type(val[0]), dict)
+            self.assertEqual(val[0], dict(cheese='stilton'))
+            self.assertEqual(type(val[1]), dict)
+            self.assertEqual(val[1], dict(socks='tartan'))
+            dct['count'] += 1
+        obj.method_with_handler_async_result_list_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultListNullJsonObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 1)
+            self.assertIsNone(val[0])
+            dct['count'] += 1
+        obj.method_with_handler_async_result_list_null_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultListComplexJsonObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 1)
+            self.assertEqual(val[0], {'outer' : {'socks' : 'tartan'}, 
+                                      'list' : ['yellow', 'blue']})
+            dct['count'] += 1
+        obj.method_with_handler_async_result_list_complex_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerSetJsonObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), set)
+            for elt in val:
+                self.assertEqual(type(elt), frozendict)
+            self.assertEqual(val, set([frozendict(cheese='stilton'), 
+                                       frozendict(socks='tartan')]))
+            dct['count'] += 1
+        obj.method_with_handler_set_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerSetNullJsonObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 1)
+            for elt in val:
+                self.assertIsNone(None)
+            dct['count'] += 1
+        obj.method_with_handler_set_null_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerSetComplexJsonObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 1)
+            self.assertEqual(val, set([frozendict({'outer' : frozendict({'socks' : 'tartan'}),
+                                                   'list' : frozenset(['yellow', 'blue'])})
+                                     ])
+                            )
+            dct['count'] += 1
+        obj.method_with_handler_set_complex_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultSetJsonObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), set)
+            for elt in val:
+                self.assertEqual(type(elt), frozendict)
+            self.assertEqual(val, set([frozendict(cheese='stilton'), 
+                                       frozendict(socks='tartan')]))
+            dct['count'] += 1
+        obj.method_with_handler_async_result_set_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultSetNullJsonObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 1)
+            for elt in val:
+                self.assertIsNone(None)
+            dct['count'] += 1
+        obj.method_with_handler_async_result_set_null_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultSetComplexJsonObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 1)
+            self.assertEqual(val, set([frozendict({'outer' : frozendict({'socks' : 'tartan'}),
+                                                   'list' : frozenset(['yellow', 'blue'])})
+                                     ])
+                            )
+            dct['count'] += 1
+        obj.method_with_handler_async_result_set_complex_json_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerListJsonArray(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 2)
+            self.assertEqual(type(val[0]), list)
+            self.assertEqual(val[0], ['green', 'blue'])
+            self.assertEqual(type(val[1]), list)
+            self.assertEqual(val[1], ['yellow', 'purple'])
+            dct['count'] += 1
+        obj.method_with_handler_list_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerListNullJsonArray(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 1)
+            self.assertIsNone(val[0])
+            dct['count'] += 1
+        obj.method_with_handler_list_null_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultListJsonArray(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 2)
+            self.assertEqual(type(val[0]), list)
+            self.assertEqual(val[0], ['green', 'blue'])
+            self.assertEqual(type(val[1]), list)
+            self.assertEqual(val[1], ['yellow', 'purple'])
+            dct['count'] += 1
+        obj.method_with_handler_async_result_list_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultListNullJsonArray(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(len(val), 1)
+            self.assertIsNone(val[0])
+            dct['count'] += 1
+        obj.method_with_handler_async_result_list_null_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultListComplexJsonArray(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(val, [[{'foo' : 'hello'}], [{'bar' : 'bye'}]])
+            dct['count'] += 1
+        obj.method_with_handler_async_result_list_complex_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerSetJsonArray(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), set)
+            for elt in val:
+                self.assertEqual(type(elt), frozenset)
+            self.assertEqual(val, set([frozenset(['green', 'blue']),
+                                       frozenset(['yellow', 'purple'])]))
+            dct['count'] += 1
+        obj.method_with_handler_set_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerSetNullJsonArray(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 1)
+            for elt in val:
+                self.assertIsNone(elt)
+            dct['count'] += 1
+        obj.method_with_handler_set_null_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerSetComplexJsonArray(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), set)
+            self.assertEqual(val, set([frozenset([frozendict({'foo' : 'hello'})]), 
+                                       frozenset([frozendict({'bar' : 'bye'})])
+                                     ])
+                            )
+            dct['count'] += 1
+        obj.method_with_handler_set_complex_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultSetJsonArray(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), set)
+            for elt in val:
+                self.assertEqual(type(elt), frozenset)
+            self.assertEqual(val, set([frozenset(['purple', 'yellow']), 
+                                       frozenset(['blue', 'green'])
+                                     ])
+                            )
+            dct['count'] += 1
+        obj.method_with_handler_async_result_set_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultSetNullJsonArray(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), set)
+            self.assertEqual(len(val), 1)
+            for elt in val:
+                self.assertIsNone(elt)
+            dct['count'] += 1
+        obj.method_with_handler_async_result_set_null_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerListComplexJsonArray(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(val, [[{'foo' : 'hello'}], [{'bar' : 'bye'}]])
+            dct['count'] += 1
+        obj.method_with_handler_list_complex_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultSetComplexJsonArray(self):
+        dct = dict(count=0)
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), set)
+            self.assertEqual(val, set([frozenset([frozendict({'foo' : 'hello'})]), 
+                                       frozenset([frozendict({'bar' : 'bye'})])
+                                     ])
+                            )
+            dct['count'] += 1
+        obj.method_with_handler_async_result_set_complex_json_array(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerListDataObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            for elt in val:
+                self.assertEqual(type(elt), dict)
+            self.assertEqual(val[0], {'foo' : 'String 1', 'bar' : 1, 'wibble' : 1.1})
+            self.assertEqual(val[1], {'foo' : 'String 2', 'bar' : 2, 'wibble' : 2.2})
+            dct['count'] += 1
+        obj.method_with_handler_list_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerListNullDataObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(type(val), list)
+            self.assertIsNone(val[0])
+            dct['count'] += 1
+        obj.method_with_handler_list_null_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerSetDataObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(val, set([frozendict({'foo' : 'String 1', 'bar' : 1, 'wibble' : 1.1}),
+                                       frozendict({'foo' : 'String 2', 'bar' : 2, 'wibble' : 2.2})
+                                      ])
+                            )
+            dct['count'] += 1
+        obj.method_with_handler_set_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerSetNullDataObject(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertEqual(val, set([None]))
+            dct['count'] += 1
+        obj.method_with_handler_set_null_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultListDataObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            for elt in val:
+                self.assertEqual(type(elt), dict)
+            self.assertEqual(val[0], {'foo' : 'String 1', 'bar' : 1, 'wibble' : 1.1})
+            self.assertEqual(val[1], {'foo' : 'String 2', 'bar' : 2, 'wibble' : 2.2})
+            dct['count'] += 1
+        obj.method_with_handler_async_result_list_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultListNullDataObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(val, [None])
+            dct['count'] += 1
+        obj.method_with_handler_async_result_list_null_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultSetDataObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(val, set([frozendict({'foo' : 'String 1', 'bar' : 1, 'wibble' : 1.1}),
+                                       frozendict({'foo' : 'String 2', 'bar' : 2, 'wibble' : 2.2})
+                                      ])
+                            )
+            dct['count'] += 1
+        obj.method_with_handler_async_result_set_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultSetNullDataObject(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(val, set([None]))
+            dct['count'] += 1
+        obj.method_with_handler_async_result_set_null_data_object(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultUserTypes(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), RefedInterface1)
+            self.assertEqual(val.get_string(), 'cheetahs')
+            dct['count'] += 1
+        obj.method_with_handler_async_result_user_types(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithConcreteHandlerUserTypeSubtype(self):
+        dct = dict(count=0)
+        def handler(obj):
+            self.assertEqual(type(obj), RefedInterface1)
+            self.assertEqual(obj.get_string(), 'echidnas')
+            dct['count'] += 1
+        arg = Factory.create_concrete_handler_user_type(handler)
+        obj.method_with_concrete_handler_user_type_subtype(arg)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithAbstractHandlerUserTypeSubtype(self):
+        dct = dict(count=0)
+        def handler(obj):
+            self.assertEqual(type(obj), RefedInterface1)
+            self.assertEqual(obj.get_string(), 'echidnas')
+            dct['count'] += 1
+        arg = Factory.create_abstract_handler_user_type(handler)
+        obj.method_with_abstract_handler_user_type_subtype(arg)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithConcreteHandlerUserTypeSubtypeExtension(self):
+        dct = dict(count=0)
+        def handler(obj):
+            self.assertEqual(type(obj), RefedInterface1)
+            self.assertEqual(obj.get_string(), 'echidnas')
+            dct['count'] += 1
+        arg = Factory.create_concrete_handler_user_type_extension(handler)
+        obj.method_with_concrete_handler_user_type_subtype_extension(arg)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerVoid(self):
+        dct = dict(count=0)
+        def handler(val):
+            self.assertIsNone(val)
+            dct['count'] += 1
+        obj.method_with_handler_void(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultVoid(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(err)
+            self.assertIsNone(val)
+            dct['count'] += 1
+        obj.method_with_handler_async_result_void(False, handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerAsyncResultVoidFails(self):
+        dct = dict(count=0)
+        def handler(val, err):
+            self.assertIsNone(val)
+            self.assertEqual(err.getMessage(), 'foo!')
+            dct['count'] += 1
+        obj.method_with_handler_async_result_void(True, handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerThrowable(self):
+        dct = dict(count=0)
+        def handler(err):
+            self.assertEqual(err.getMessage(), 'cheese!')
+            dct['count'] += 1
+        obj.method_with_handler_throwable(handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithHandlerGenericUserType(self):
+        def run_test(value, assertion):
+            dct = dict(count=0)
+            def handler(obj):
+                self.assertIsNotNone(obj)
+                self.assertEqual(type(obj), GenericRefedInterface)
+                assertion(obj.get_value())
+                dct['count'] += 1
+            obj.method_with_handler_generic_user_type(value, handler)
+            self.assertEqual(dct['count'], 1)
+        run_test('string_value', lambda x: self.assertEqual(x, 'string_value'))
+        run_test({'key' : 'key_value'}, lambda x: self.assertEqual(x, {'key' : 'key_value'}))
+        run_test(['foo', 'bar', 'juu'], lambda x: self.assertEqual(x, ['foo', 'bar', 'juu']))
+
+
+    def testMethodWithHandlerAsyncResultGenericUserType(self):
+        def run_test(value, assertion):
+            dct = dict(count=0)
+            def handler(obj, err):
+                self.assertIsNone(err)
+                self.assertIsNotNone(obj)
+                self.assertEqual(type(obj), GenericRefedInterface)
+                assertion(obj.get_value())
+                dct['count'] += 1
+            obj.method_with_handler_async_result_generic_user_type(value, handler)
+            self.assertEqual(dct['count'], 1)
+        run_test('string_value', lambda x: self.assertEqual(x, 'string_value'))
+        run_test({'key' : 'key_value'}, lambda x: self.assertEqual(x, {'key' : 'key_value'}))
+        run_test(['foo', 'bar', 'juu'], lambda x: self.assertEqual(x, ['foo', 'bar', 'juu']))
+
+
+    def testMethodWithGenericParam(self):
+        obj.method_with_generic_param('String', 'foo')
+        obj.method_with_generic_param('JsonObject', {'foo' : 'hello','bar' : 123})
+        obj.method_with_generic_param('JsonArray', ['foo', 'bar', 'wib'])
+
+
+    def testMethodWithGenericHandler(self):
+        dct = dict(count=0)
+        def str_handler(val):
+            self.assertEqual(type(val), unicode)
+            self.assertEqual(val, 'foo')
+            dct['count'] += 1
+        obj.method_with_generic_handler('String', str_handler)
+        self.assertEqual(dct['count'], 1)
+
+        dct = dict(count=0)
+        def do_handler(val):
+            self.assertEqual(val.getString(), 'bar')
+            dct['count'] += 1
+        obj.method_with_generic_handler('Ref', do_handler)
+        self.assertEqual(dct['count'], 1)
+
+        dct = dict(count=0)
+        def json_obj_handler(val):
+            self.assertEqual(type(val), dict)
+            self.assertEqual(val, {'foo' : 'hello', 'bar' : 123})
+            dct['count'] += 1
+        obj.method_with_generic_handler('JsonObject', json_obj_handler)
+        self.assertEqual(dct['count'], 1)
+
+        dct = dict(count=0)
+        def json_arr_handler(val):
+            self.assertEqual(type(val), list)
+            self.assertEqual(val, ['foo', 'bar', 'wib'])
+            dct['count'] += 1
+        obj.method_with_generic_handler('JsonArray', json_arr_handler)
+        self.assertEqual(dct['count'], 1)
+
+        dct = dict(count=0)
+        def json_obj_complex_handler(val):
+            self.assertEqual(type(val), dict)
+            self.assertEqual(val, {'outer' : {'foo' : 'hello'}, 
+                                   'bar' : ['this', 'that']})
+            dct['count'] += 1
+        obj.method_with_generic_handler('JsonObjectComplex', json_obj_complex_handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testMethodWithGenericHandlerAsyncResult(self):
+        dct = dict(count=0)
+        def str_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), unicode)
+            self.assertEqual(val, 'foo')
+            dct['count'] += 1
+        obj.method_with_generic_handler_async_result('String', str_handler)
+        self.assertEqual(dct['count'], 1)
+
+        dct = dict(count=0)
+        def do_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(val.getString(), 'bar')
+            dct['count'] += 1
+        obj.method_with_generic_handler_async_result('Ref', do_handler)
+        self.assertEqual(dct['count'], 1)
+
+        dct = dict(count=0)
+        def json_obj_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), dict)
+            self.assertEqual(val, {'foo' : 'hello', 'bar' : 123})
+            dct['count'] += 1
+        obj.method_with_generic_handler_async_result('JsonObject', json_obj_handler)
+        self.assertEqual(dct['count'], 1)
+
+        dct = dict(count=0)
+        def json_arr_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), list)
+            self.assertEqual(val, ['foo', 'bar', 'wib'])
+            dct['count'] += 1
+        obj.method_with_generic_handler_async_result('JsonArray', json_arr_handler)
+        self.assertEqual(dct['count'], 1)
+
+        dct = dict(count=0)
+        def json_obj_complex_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(type(val), dict)
+            self.assertEqual(val, {'outer' : {'foo' : 'hello'}, 
+                                   'bar' : ['this', 'that']})
+            dct['count'] += 1
+        obj.method_with_generic_handler_async_result('JsonObjectComplex', json_obj_complex_handler)
+        self.assertEqual(dct['count'], 1)
+
+
+    def testJsonParams(self):
+        obj.method_with_json_params({'cat' : 'lion', 'cheese' : 'cheddar'}, 
+                                    ['house', 'spider'])
+
+
+    def testNullJsonParams(self):
+        self.assertRaises(TypeError, obj.method_with_null_json_params, None, None)
+
+
+    def testJsonHandlerParams(self):
+        dct = dict(count=0)
+        def obj_handler(val):
+            self.assertEqual(val, {'cheese' : 'stilton'})
+            dct['count'] += 1
+        def arr_handler(val):
+            self.assertEqual(val, ['socks', 'shoes'])
+            dct['count'] += 1
+        obj.method_with_handler_json(obj_handler, arr_handler)
+        self.assertEqual(dct['count'], 2)
+
+
+    def testNullJsonHandlerParams(self):
+        dct = dict(count=0)
+        def obj_handler(val):
+            self.assertIsNone(val)
+            dct['count'] += 1
+        def arr_handler(val):
+            self.assertIsNone(val)
+            dct['count'] += 1
+        obj.method_with_handler_null_json(obj_handler, arr_handler)
+        self.assertEqual(dct['count'], 2)
+
+
+    def testComplexJsonHandlerParams(self):
+        dct = dict(count=0)
+        def obj_handler(val):
+            self.assertEqual(val, {'outer' : {'socks' : 'tartan'},
+                                   'list' : ['yellow', 'blue']})
+            dct['count'] += 1
+        def arr_handler(val):
+            self.assertEqual(val, [[{'foo' : 'hello'}], [{'bar' : 'bye'}]])
+            dct['count'] += 1
+        obj.method_with_handler_complex_json(obj_handler, arr_handler)
+        self.assertEqual(dct['count'], 2)
+
+
+    def testJsonHandlerAsyncResultParams(self):
+        dct = dict(count=0)
+        def obj_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(val, {'cheese' : 'stilton'})
+            dct['count'] += 1
+        def arr_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(val, ['socks', 'shoes'])
+            dct['count'] += 1
+        obj.method_with_handler_async_result_json_object(obj_handler)
+        obj.method_with_handler_async_result_json_array(arr_handler)
+        self.assertEqual(dct['count'], 2)
+
+
+    def testNullJsonHandlerAsyncResultParams(self):
+        dct = dict(count=0)
+        def obj_handler(val, err):
+            self.assertIsNone(val)
+            self.assertIsNone(err)
+            dct['count'] += 1
+        def arr_handler(val, err):
+            self.assertIsNone(val)
+            self.assertIsNone(err)
+            dct['count'] += 1
+
+        obj.method_with_handler_async_result_null_json_object(obj_handler)
+        obj.method_with_handler_async_result_null_json_array(arr_handler)
+        self.assertEqual(dct['count'], 2)
+
+
+    def testComplexJsonHandlerAsyncResultParams(self):
+        dct = dict(count=0)
+        def obj_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(val, {'outer' : {'socks' : 'tartan'},
+                                   'list' : ['yellow', 'blue']})
+            dct['count'] += 1
+        def arr_handler(val, err):
+            self.assertIsNone(err)
+            self.assertEqual(val, [{'foo' : 'hello'}, {'bar' : 'bye'}])
+            dct['count'] += 1
+        obj.method_with_handler_async_result_complex_json_object(obj_handler)
+        obj.method_with_handler_async_result_complex_json_array(arr_handler)
+        self.assertEqual(dct['count'], 2)
+
+
+    def testBasicReturns(self):
+        ret = obj.method_with_byte_return()
+        self.assertEqual(type(ret), int)
+        self.assertEqual(ret, 123)
+        ret = obj.method_with_short_return()
+        self.assertEqual(type(ret), int)
+        self.assertEqual(ret, 12345)
+        ret = obj.method_with_int_return()
+        self.assertEqual(type(ret), int)
+        self.assertEqual(ret, 12345464)
+        ret = obj.method_with_long_return()
+        self.assertEqual(type(ret), long)
+        self.assertEqual(ret, 65675123)
+        ret = obj.method_with_float_return()
+        self.assertEqual(type(ret), float)
+        self.assertEqual(ret, 1.23)
+        ret = obj.method_with_double_return()
+        self.assertEqual(type(ret), float)
+        self.assertEqual(ret, 3.34535)
+        ret = obj.method_with_boolean_return()
+        self.assertEqual(type(ret), bool)
+        self.assertEqual(ret, True)
+        ret = obj.method_with_char_return()
+        self.assertEqual(type(ret), unicode)
+        self.assertEqual(ret, 'Y')
+        ret = obj.method_with_string_return()
+        self.assertEqual(type(ret), unicode)
+        self.assertEqual(ret, 'orangutan')
+
+
+    def testVertxGenReturn(self):
+        ret = obj.method_with_vertx_gen_return()
+        self.assertEqual(type(ret), RefedInterface1)
+        self.assertEqual(ret.get_string(), 'chaffinch')
+
+
+    def testVertxGenNullReturn(self):
+        ret = obj.method_with_vertx_gen_null_return()
+        self.assertIsNone(ret)
+
+
+    def testAbstractVertxGenReturn(self):
+        ret = obj.method_with_abstract_vertx_gen_return()
+        self.assertIsInstance(ret, RefedInterface2)
+        self.assertEqual(ret.get_string(), 'abstractchaffinch')
 
 
     #def testMapComplexJsonArrayReturn(self):
-        #map = obj.method_with_map_complex_json_array_return {}
-        #m = map['foo']
-        #self.equals m, [{'foo' => 'hello'}, {'bar' => 'bye'}]
+        #def handler(map):
+            #m = map['foo']
+            #self.assertEqual(m, [{'foo' : 'hello'}, {'bar' : 'bye'}])
+        #obj.method_with_map_complex_json_array_return(handler)
 
 
     #def testOverloadedMethods(self):
         #@refed_obj.set_string('dog')
         #called = false
         #ret = obj.overloaded_method('cat', @refed_obj)
-        #self.equals(ret, 'meth1')
-        #ret = obj.overloaded_method('cat', @refed_obj, 12345) { |animal| self.equals(animal, 'giraffe') ; called = true }
-        #self.equals(ret, 'meth2')
-        #self.equals(called, true)
+        #self.assertEqual(ret, 'meth1')
+        #ret = obj.overloaded_method('cat', @refed_obj, 12345) { |animal| self.assertEqual(animal, 'giraffe') ; called = true }
+        #self.assertEqual(ret, 'meth2')
+        #self.assertEqual(called, true)
         #called = false
         ## for some reason animal is sometimes equals to giraffe and sometimes empty
         #ret = obj.overloaded_method('cat') { |animal| called = true }
-        #self.equals(ret, 'meth3')
-        #self.equals(called, true)
+        #self.assertEqual(ret, 'meth3')
+        #self.assertEqual(called, true)
         #called = false
-        #ret = obj.overloaded_method('cat', @refed_obj) { |animal| self.equals(animal, 'giraffe') ; called = true }
-        #self.equals(ret, 'meth4')
-        #self.equals(called, true)
+        #ret = obj.overloaded_method('cat', @refed_obj) { |animal| self.assertEqual(animal, 'giraffe') ; called = true }
+        #self.assertEqual(ret, 'meth4')
+        #self.assertEqual(called, true)
         #self.argument_error { obj.overloaded_method 'cat' }
         #self.argument_error { obj.overloaded_method('cat', @refed_obj, 12345) }
         #self.argument_error { obj.overloaded_method {} }
@@ -1006,29 +1188,29 @@ class TestAPI(unittest.TestCase):
 
     #def testSuperInterfaces(self):
         #obj.super_method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
-        #self.equals(obj.is_a?(Testmodel::SuperInterface1), true)
+        #self.assertEqual(obj.is_a?(Testmodel::SuperInterface1), true)
         #obj.other_super_method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, true, 88, 'foobar')
-        #self.equals(obj.is_a?(Testmodel::SuperInterface2), true)
+        #self.assertEqual(obj.is_a?(Testmodel::SuperInterface2), true)
 
 
     #def testMethodWithGenericReturn(self):
         #ret = obj.method_with_generic_return('JsonObject')
-        #self.equals(ret.class, Hash)
-        #self.equals(ret, {'foo'=>'hello','bar'=>123})
+        #self.assertEqual(ret.class, Hash)
+        #self.assertEqual(ret, {'foo'=>'hello','bar'=>123})
         #ret = obj.method_with_generic_return('JsonArray')
-        #self.equals(ret.class, Array)
-        #self.equals(ret, %w(foo bar wib))
+        #self.assertEqual(ret.class, Array)
+        #self.assertEqual(ret, %w(foo bar wib))
 
 
     #def testFluentMethod(self):
         #ret = obj.fluent_method('bar')
-        #self.equals(ret, obj)
+        #self.assertEqual(ret, obj)
 
 
     #def testStaticFactoryMethod(self):
         #ret = Testmodel::TestInterface.static_factory_method('bar')
-        #self.equals(ret.class, Testmodel::RefedInterface1)
-        #self.equals(ret.get_string, 'bar')
+        #self.assertEqual(ret.class, Testmodel::RefedInterface1)
+        #self.assertEqual(ret.get_string, 'bar')
 
 
     #def testMethodWithCachedReturn(self):
@@ -1047,9 +1229,9 @@ class TestAPI(unittest.TestCase):
 
     #def testJsonReturns(self):
         #ret = obj.method_with_json_object_return
-        #self.equals(ret, {'cheese'=>'stilton'})
+        #self.assertEqual(ret, {'cheese'=>'stilton'})
         #ret = obj.method_with_json_array_return
-        #self.equals(ret, %w(socks shoes))
+        #self.assertEqual(ret, %w(socks shoes))
 
 
     #def testNullJsonReturns(self):
@@ -1066,64 +1248,9 @@ class TestAPI(unittest.TestCase):
         #self.equals ret, [{'foo' => 'hello'}, {'bar' => 'bye'}]
 
 
-    #def testJsonParams(self):
-        #obj.method_with_json_params({'cat' => 'lion', 'cheese' => 'cheddar'}, %w(house spider))
-
-
-    #def testNullJsonParams(self):
-        #self.argument_error { obj.method_with_null_json_params(nil, nil) }
-
-
-    #def testJsonHandlerParams(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_json(
-            #Proc.new { |val| self.equals(val, {'cheese'=>'stilton'}); dct['count'] += 1 }) do  |val|
-          #self.equals(val, %w(socks shoes)); dct['count'] += 1
-        #end
-        #self.equals(2, count)
-
-
-    #def testNullJsonHandlerParams(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_null_json(
-            #Proc.new { |val| self.is_nil(val); dct['count'] += 1 }) do |val|
-          #self.is_nil(val); dct['count'] += 1
-        #end
-        #self.equals(2, count)
-
-
-    #def testComplexJsonHandlerParams(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_complex_json(
-            #Proc.new { |val| self.equals(val, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']}); dct['count'] += 1 }) do |val|
-          #self.equals(val, [[{'foo' => 'hello'}], [{'bar' => 'bye'}]])
-          #dct['count'] += 1
-        #end
-        #self.equals(2, count)
-
-
-    #def testJsonHandlerAsyncResultParams(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_json_object { |err,val| self.is_nil(err); Assert.equals(val, {'cheese'=>'stilton'}); dct['count'] += 1 }
-        #obj.method_with_handler_async_result_json_array { |err,val| self.is_nil(err); Assert.equals(val, ['socks','shoes']); dct['count'] += 1 }
-        #self.equals(2, count)
-
-
-    #def testNullJsonHandlerAsyncResultParams(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_null_json_object { |err,val| self.is_nil(err); Assert.is_nil(val); dct['count'] += 1 }
-        #obj.method_with_handler_async_result_null_json_array { |err,val| self.is_nil(err); Assert.is_nil(val); dct['count'] += 1 }
-        #self.equals(2, count)
-
-
-    #def testEnumParam(self):
-        #ret = obj.method_with_enum_param('sausages', :TIM)
-        #self.equals(ret, 'sausagesTIM')
-
-
     #def testEnumReturn(self):
         #ret = obj.method_with_enum_return('JULIEN')
-        #self.equals(:JULIEN, ret)
+        #self.assertEqual(:JULIEN, ret)
 
 
     #def testMapReturn(self):
@@ -1401,27 +1528,12 @@ class TestAPI(unittest.TestCase):
         #ret = obj.method_with_set_vertx_gen_return
         #self.has_class ret, Set
         #ret.each { |elt| self.has_class(elt, Testmodel::RefedInterface1) }
-        #self.equals(ret.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
-
-
-    #def testComplexJsonHandlerAsyncResultParams(self):
-        #dct = dict(count=0)
-        #obj.method_with_handler_async_result_complex_json_object { |err,val|
-          #self.is_nil(err)
-          #self.equals(val, {'outer' => {'socks' => 'tartan'}, 'list'=> ['yellow', 'blue']})
-          #dct['count'] += 1
-        #}
-        #obj.method_with_handler_async_result_complex_json_array { |err,val|
-          #self.is_nil(err)
-          #self.equals(val, [{'foo' => 'hello'}, {'bar' => 'bye'}])
-          #dct['count'] += 1
-        #}
-        #self.equals(2, count)
+        #self.assertEqual(ret.map { |o| o.get_string }.to_set, Set.new(%w(foo bar)))
 
 
     #def testThrowableReturn(self):
         #ret = obj.method_with_throwable_return 'bogies'
-        #self.equals('bogies', ret.message)
+        #self.assertEqual('bogies', ret.message)
 
 
     #def testCustomModule(self):
@@ -1475,6 +1587,11 @@ class TestAPI(unittest.TestCase):
             #{'foo'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('foo'),'eek'=>Testmodel::RefedInterface1.new(RefedInterface1Impl.new).set_string('bar')}
         #)
         #self.argument_error { obj.method_with_list_params(nil, nil, nil, nil, nil, nil, nil, nil) }
+
+
+    #def testEnumParam(self):
+        #ret = obj.method_with_enum_param('sausages', :TIM)
+        #self.assertEqual(ret, 'sausagesTIM')
 
 
 if __name__ == "__main__":

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -21,7 +21,7 @@ from py4j.protocol import Py4JJavaError
 
 util.vertx_init()
 
-with util.handle_java_error():
+with util.handle_vertx_shutdown(on_error_only=True):
     jvm = util.jvm
     obj = TestInterface(jvm.io.vertx.codegen.testmodel.TestInterfaceImpl())
     refed_obj = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
@@ -1658,7 +1658,7 @@ if __name__ == "__main__":
     meth = sys.argv[-1]
     err = False
     print("Testing {}".format(meth))
-    with util.handle_java_error():
+    with util.handle_vertx_shutdown():
         if meth == "testEverything":
             out = unittest.main(exit=False, argv=[sys.argv[0]])
             result = out.result
@@ -1667,7 +1667,6 @@ if __name__ == "__main__":
         else:
             case = TestAPI(meth)
             case.debug()
-        util.vertx_shutdown()
-        if err:
-            sys.exit(1)
+    if err:
+        sys.exit(1)
 

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -10,6 +10,7 @@ from acme_python.pkg.my_interface import MyInterface
 from acme_python.sub.sub_interface import SubInterface
 
 from vertx_python import util
+from vertx_python.compat import long, unicode
 
 util.vertx_init()
 
@@ -116,7 +117,7 @@ class TestAPI(unittest.TestCase):
             dct['count'] += 1
         def string_handler(s, err):
             self.assertEqual(type(s), str)
-            self.assertEqual('quux!', str)
+            self.assertEqual('quux!', s)
             self.assertIsNone(err)
             dct['count'] += 1
         obj.method_with_handler_async_result_byte(False, byte_handler)
@@ -126,7 +127,7 @@ class TestAPI(unittest.TestCase):
         obj.method_with_handler_async_result_float(False, float_handler)
         obj.method_with_handler_async_result_double(False, double_handler)
         obj.method_with_handler_async_result_boolean(False, boolean_handler)
-        obj.method_with_handler_async_result_char(False, char_handler)
+        obj.method_with_handler_async_result_character(False, char_handler)
         obj.method_with_handler_async_result_string(False, string_handler)
         self.assertEqual(dct['count'], 9)
 
@@ -146,7 +147,7 @@ class TestAPI(unittest.TestCase):
         obj.method_with_handler_async_result_float(True, handler)
         obj.method_with_handler_async_result_double(True, handler)
         obj.method_with_handler_async_result_boolean(True, handler)
-        obj.method_with_handler_async_result_char(True, handler)
+        obj.method_with_handler_async_result_character(True, handler)
         obj.method_with_handler_async_result_string(True, handler)
         self.assertEqual(dct['count'], 9)
 
@@ -169,13 +170,13 @@ class TestAPI(unittest.TestCase):
 
 
     def testDataObjectParam(self):
-        data_object = {"foo" : "Hello", "bar" : 123, "wibble" : 1.23}
-        obj.method_with_data_object_param(data_object)
+        data_object = {"foo" : "hello", "bar" : 123, "wibble" : 1.23}
+        obj.method_with_data_object_param(**data_object)
 
 
     def testNullDataObjectParam(self):
         data_object = {}
-        obj.method_with_null_data_object_param(data_object=data_object)
+        obj.method_with_null_data_object_param(**data_object)
 
 
     def testMethodWithHandlerDataObject(self):
@@ -349,9 +350,10 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(len(val), 2)
             for item in val:
                 self.assertEqual(type(item), RefedInterface1)
-            self.assertSetEqual(val, set(['foo', 'bar']))
+            self.assertSetEqual(set([x.get_string() for x in val]), 
+                                set(['foo', 'bar']))
             dct['count'] += 1
-        obj.method_with_handler_list_vertx_gen(handler)
+        obj.method_with_handler_set_vertx_gen(handler)
         self.assertEqual(dct['count'], 1)
 
 
@@ -362,7 +364,8 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(len(val), 2)
             for item in val:
                 self.assertIsInstance(item, RefedInterface2)
-            self.assertSetEqual(val, set(['abstractfoo', 'abstractbar']))
+            self.assertSetEqual(set([x.get_string() for x in val]), 
+                                set(['abstractfoo', 'abstractbar']))
             dct['count'] += 1
 
         obj.method_with_handler_set_abstract_vertx_gen(handler)
@@ -377,7 +380,8 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(len(val), 2)
             for item in val:
                 self.assertEqual(type(item), RefedInterface1)
-            self.assertSetEqual(set([x.get_string() for x in val]), set(['foo', 'bar']))
+            self.assertSetEqual(set([x.get_string() for x in val]), 
+                                set(['foo', 'bar']))
             dct['count'] += 1
 
         obj.method_with_handler_async_result_set_vertx_gen(handler)
@@ -392,7 +396,8 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(len(val), 2)
             for item in val:
                 self.assertIsInstance(item, RefedInterface2)
-            self.assertSetEqual(set([x.get_string() for x in val]), set(['abstractfoo', 'abstractbar']))
+            self.assertSetEqual(set([x.get_string() for x in val]), 
+                                set(['abstractfoo', 'abstractbar']))
             dct['count'] += 1
 
         obj.method_with_handler_async_result_set_abstract_vertx_gen(handler)
@@ -408,8 +413,9 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(val[0], dict(cheese='stilton'))
             self.assertEqual(type(val[1]), dict)
             self.assertEqual(val[1], dict(socks='tartan'))
+            dct['count'] += 1
         obj.method_with_handler_list_json_object(handler)
-        self.assertEqual(dct['count'], 2)
+        self.assertEqual(dct['count'], 1)
 
 
     def testMethodWithHandlerListNullJsonObject(self):
@@ -418,6 +424,7 @@ class TestAPI(unittest.TestCase):
             self.assertEqual(type(val), list)
             self.assertEqual(len(val), 1)
             self.assertIsNone(val[0])
+            dct['count'] += 1
         obj.method_with_handler_list_null_json_object(handler)
         self.assertEqual(dct['count'], 1)
 
@@ -1475,6 +1482,6 @@ if __name__ == "__main__":
     print("Testing {}".format(meth))
     with util.handle_java_error():
         case = TestAPI(meth)
-        case()
+        case.debug()
         util.vertx_shutdown()
 

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -18,13 +18,10 @@ with util.handle_java_error():
     refed_obj2 = RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl())
 
 def testMethodWithBasicParams():
-    print("MADE IT TO HERE")
-    obj.method_with_basic_params(b'123', 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88, 'foobar')
-
+    obj.method_with_basic_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88, 'foobar')
 
 def testMethodWithBasicBoxedParams():
-    obj.method_with_basic_boxed_params(b'123', 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88)
-
+    obj.method_with_basic_boxed_params(123, 12345, 1234567, 1265615234, 12.345, 12.34566, True, 88)
 
 def testMethodWithHandlerBasicTypes():
     dct = dict(count=0)
@@ -172,7 +169,8 @@ def testDataObjectParam():
 
 
 def testNullDataObjectParam():
-    obj.method_with_null_data_object_param(None);
+    data_object = {}
+    obj.method_with_null_data_object_param(data_object)
 
 
 def testMethodWithHandlerDataObject():
@@ -1414,3 +1412,5 @@ if __name__ == "__main__":
     print("calling {}".format(meth))
     with util.handle_java_error():
         globals()[meth]()
+        util.java_gateway.shutdown()
+

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1601,7 +1601,8 @@ class TestAPI(unittest.TestCase):
             [['foo'], ['blah']],
             [RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
              RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')],
-            [{'foo':'String 1','bar':1,'wibble':1.1}, {'foo':'String 2','bar':2,'wibble':2.2}]
+            [{'foo':'String 1','bar':1,'wibble':1.1}, {'foo':'String 2','bar':2,'wibble':2.2}],
+            ['JULIEN', 'TIM']
         )
 
     def testMethodWithSetParams(self):
@@ -1616,7 +1617,8 @@ class TestAPI(unittest.TestCase):
             set([RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
              RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')]),
             set([frozendict({'foo':'String 1','bar':1,'wibble':1.1}), 
-                 frozendict({'foo':'String 2','bar':2,'wibble':2.2})])
+                 frozendict({'foo':'String 2','bar':2,'wibble':2.2})]),
+            set(['TIM', 'JULIEN'])
         )
 
     def testMethodWithMapParams(self):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -1590,58 +1590,47 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(ret, "olleh")
 
 
-    #def testMethodWithListParams(self):
-        #obj.method_with_list_params(
-            #['foo', 'bar'],
-            #[2, 3],
-            #[12, 13],
-            #[1234, 1345],
-            #[123, 456],
-            #[{'foo':'bar'}, {'eek':'wibble'}],
-            #[['foo'], ['blah']],
-            #[RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
-             #RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')],
-            #[{'foo':'String 1','bar':1,'wibble':1.1}, {'foo':'String 2','bar':2,'wibble':2.2}]
-        #)
-        #self.assertRaises(TypeError,
-                          #obj.method_with_list_params(None, None, None, None, 
-                                                      #None, None, None, None))
+    def testMethodWithListParams(self):
+        obj.method_with_list_params(
+            ['foo', 'bar'],
+            [2, 3],
+            [12, 13],
+            [1234, 1345],
+            [123, 456],
+            [{'foo':'bar'}, {'eek':'wibble'}],
+            [['foo'], ['blah']],
+            [RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
+             RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')],
+            [{'foo':'String 1','bar':1,'wibble':1.1}, {'foo':'String 2','bar':2,'wibble':2.2}]
+        )
 
+    def testMethodWithSetParams(self):
+        obj.method_with_set_params(
+            set(['foo', 'bar']),
+            set([2, 3]),
+            set([12, 13]),
+            set([1234, 1345]),
+            set([123, 456]),
+            set([frozendict({'foo':'bar'}), frozendict({'eek':'wibble'})]),
+            set([frozenset(['foo']), frozenset(['blah'])]),
+            set([RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
+             RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')]),
+            set([frozendict({'foo':'String 1','bar':1,'wibble':1.1}), 
+                 frozendict({'foo':'String 2','bar':2,'wibble':2.2})])
+        )
 
-    #def testMethodWithSetParams(self):
-        #obj.method_with_set_params(
-            #set(['foo', 'bar']),
-            #set([2, 3]),
-            #set([12, 13]),
-            #set([1234, 1345]),
-            #set([123, 456]),
-            #set([frozendict({'foo':'bar'}), frozendict({'eek':'wibble'})]),
-            #set([frozenset(['foo']), frozenset(['blah'])]),
-            #set([RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'), 
-             #RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')]),
-            #set([frozendict({'foo':'String 1','bar':1,'wibble':1.1}), 
-                 #frozendict({'foo':'String 2','bar':2,'wibble':2.2})])
-        #)
-        #self.assertRaises(TypeError,
-                          #obj.method_with_set_params(None, None, None, None, 
-                                                     #None, None, None, None))
-
-
-    #def testMethodWithMapParams(self):
-        #obj.method_with_map_params(
-            #{'foo' : 'bar', 'eek' : 'wibble'},
-            #{'foo' : 2, 'eek' : 3},
-            #{'foo' : 12, 'eek' : 13},
-            #{'foo' : 1234, 'eek' : 1345},
-            #{'foo' : 123, 'eek' : 456},
-            #{'foo' : {'foo' : 'bar'}, 'eek' : {'eek' : 'wibble'}},
-            #{'foo' : ['foo'], 'eek' : ['blah']},
-            #{'foo' : RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'),
-             #'eek' : RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')}
-        #)
-        #self.assertRaises(TypeError,
-                          #obj.method_with_map_params(None, None, None, None, 
-                                                     #None, None, None, None))
+    def testMethodWithMapParams(self):
+        obj.method_with_map_params(
+            {'foo' : 'bar', 'eek' : 'wibble'},
+            {'foo' : 2, 'eek' : 3},
+            {'foo' : 12, 'eek' : 13},
+            {'foo' : 1234, 'eek' : 1345},
+            {'foo' : 123, 'eek' : 456},
+            {'foo' : {'foo' : 'bar'}, 'eek' : {'eek' : 'wibble'}},
+            {'foo' : ['foo'], 'eek' : ['blah']},
+            {'foo' : RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('foo'),
+             'eek' : RefedInterface1(jvm.io.vertx.codegen.testmodel.RefedInterface1Impl()).set_string('bar')}
+        )
 
 
     def testEnumReturn(self):

--- a/src/test/resources/api_test.py
+++ b/src/test/resources/api_test.py
@@ -144,7 +144,7 @@ class TestAPI(unittest.TestCase):
         def handler(x, err):
             self.assertIsNone(x);
             self.assertIsNotNone(err);
-            self.assertEqual("foobar!", err.getMessage());
+            self.assertEqual("foobar!", str(err));
             dct['count'] += 1
 
         obj.method_with_handler_async_result_byte(True, handler)
@@ -215,7 +215,7 @@ class TestAPI(unittest.TestCase):
         def handler(option, err):
             self.assertIsNone(option)
             self.assertIsNotNone(err)
-            self.assertEqual("foobar!", err.getMessage())
+            self.assertEqual("foobar!", str(err))
             dct['count'] += 1
         obj.method_with_handler_async_result_data_object(True, handler)
         self.assertEqual(dct['count'], 1)
@@ -882,7 +882,7 @@ class TestAPI(unittest.TestCase):
         dct = dict(count=0)
         def handler(val, err):
             self.assertIsNone(val)
-            self.assertEqual(err.getMessage(), 'foo!')
+            self.assertEqual(str(err), 'foo!')
             dct['count'] += 1
         obj.method_with_handler_async_result_void(True, handler)
         self.assertEqual(dct['count'], 1)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,16 @@
+from vertx_python.core import vertx
+
+def main():
+    def cb1(cv, uh):
+        print("got clustered vertx {}".format(cv))
+        print("got huh {}".format(uh))
+
+        def cb2(c, uh):
+            print("got huh {}".format(uh))
+            print("got c {}".format(c))
+        cv.shared_data().get_cluster_wide_map("mymap", cb2)
+
+    vertx.Vertx.clustered_vertx(cb1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This addresses issue #1, and additionally gets all but three of the API tests working. The failing tests can't be fixed without either a Py4J enhancement (see https://github.com/bartdag/py4j/issues/163), or a Java shim between the Python code and the Vert.x Java API.

There are a few other pieces here that are probably worth calling out:

1) Java sets are being translated to Python sets, which requires that any list/map inside the set to be be converted to a `frozenset`/`frozendict` (I've added the`frozendict` type to `vertx_python.util`). It also requires some customized JSON decoding/encoding. It seems to be working, but it would simplify things significantly to just translate a Java set to a Python list.

2) Currently, JUnit just executes a single unit test, which triggers all 121+ Python unit tests (using the Python `unittest` module). If any of those fail, the single JUnit test reports failure. I do it this way because the performance of having a unique JUnit test for every Python unit test is atrocious, due to the high overhead of launching a Python process and launching/shutting down the Java GatewayServer/GatewayClient.

3) Because we need to use the Py4J callback server, it's necessary to be very careful about how the Python script is shut down. `vertx_python.util.vertx_shutdown()` _must_ be called prior to the main thread exiting, or the program will hang due to the callback server continuing to run in a background thread. I've added a `handle_vertx_shutdown()` context manager to help with this.

4) There's no attempt at `asyncio` integration here - everything is callback based. I do have another branch where I've demonstrated how `asyncio` integration can be done - and I'm working through getting all the unit tests working there. It sounds like the preference is to have that eventually become a completely separate repo, perhaps sharing some common code with this one?

5) The generated code should be compatible with Python 2.7 and Python 3.x. At some point we may want to add a Python3 specific verticle, which would use "python3" rather than "python" to launch the Python script.
